### PR TITLE
Fix structured errors for both F# and C#. Fixes #43

### DIFF
--- a/src/Error.fs
+++ b/src/Error.fs
@@ -1,13 +1,9 @@
 namespace Fusion
 
 open System
-open System.Net.Http
 open System.Collections.Generic
 
 open Thoth.Json.Net
-
-/// Will be raised if decoding a response fails.
-exception DecodeException of string
 
 type ErrorValue () =
     static member val Decoder : Decoder<ErrorValue> =
@@ -43,45 +39,51 @@ type ResponseException (message : string) =
     member val Code = 400 with get, set
     member val Missing : IEnumerable<IDictionary<string, ErrorValue>> = Seq.empty with get, set
     member val Duplicated : IEnumerable<IDictionary<string, ErrorValue>> = Seq.empty with get, set
+    member val InnerException : Exception = null with get, set
 
+and ResponseError = {
+    Code : int
+    Message : string
+    Missing : Map<string, ErrorValue> seq
+    Duplicated : Map<string, ErrorValue> seq
+    InnerException : exn option
+}
     with
-        static member Decoder : Decoder<ResponseException> =
+        static member Decoder : Decoder<ResponseError> =
             Decode.object (fun get ->
                 let message = get.Required.Field "message" Decode.string
+                {
+                    Code = get.Required.Field "code" Decode.int
+                    Message = get.Required.Field "message" Decode.string
+                    Missing =
+                        let missing = get.Optional.Field "missing" (Decode.array (Decode.dict ErrorValue.Decoder))
+                        match missing with
+                        | Some missing -> missing |> Seq.ofArray
+                        | None -> Seq.empty
+                    Duplicated =
+                        let duplicated = get.Optional.Field "duplicated" (Decode.array (Decode.dict ErrorValue.Decoder))
+                        match duplicated with
+                        | Some duplicated -> duplicated |> Seq.ofArray
+                        | None -> Seq.empty
+                    InnerException = None
+                })
 
-                let error = ResponseException message
-                error.Code <- get.Required.Field "code" Decode.int
+        static member empty =
+            {
+               Code = 400
+               Message = String.Empty
+               Missing = Seq.empty
+               Duplicated = Seq.empty
+               InnerException = None
+           }
 
-
-                let missing = get.Optional.Field "missing" (Decode.array (Decode.dict ErrorValue.Decoder))
-                match missing with
-                | Some missing ->
-                    error.Missing <- missing |> Seq.map (Map.toSeq >> dict)
-                | None -> ()
-
-                let duplicated = get.Optional.Field "duplicated" (Decode.array (Decode.dict ErrorValue.Decoder))
-                match duplicated with
-                | Some duplicated ->
-                    error.Duplicated <- duplicated |> Seq.map (Map.toSeq >> dict)
-                | None -> ()
-
-                error
-            )
-
-type ResponseError =
-    /// Exception (internal error). This should never happen.
-    | Exception of exn
-    /// JSON decode error (unable to decode the response)
-    | DecodeError of string
-    /// Error response from server.
-    | HttpResponse of HttpResponseMessage*IO.Stream
-
-type ErrorResponse = {
-    Error : ResponseException
+type ApiResponseError = {
+    Error : ResponseError
 } with
     static member Decoder =
         Decode.object (fun get ->
             {
-                Error = get.Required.Field "error" ResponseException.Decoder
+                Error = get.Required.Field "error" ResponseError.Decoder
             }
         )
+

--- a/src/assets/CreateAssets.fs
+++ b/src/assets/CreateAssets.fs
@@ -81,6 +81,6 @@ type CreateAssetsExtensions =
             | Ok response ->
                 return response |> Seq.map (fun asset -> asset.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/src/assets/DeleteAssets.fs
+++ b/src/assets/DeleteAssets.fs
@@ -75,7 +75,7 @@ type DeleteAssetsExtensions =
             | Ok response ->
                 return ()
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         } :> Task
 

--- a/src/assets/FilterAssets.fs
+++ b/src/assets/FilterAssets.fs
@@ -108,6 +108,6 @@ type FilterAssetsExtensions =
                         Items = assets.Items |> Seq.map (fun asset -> asset.ToPoco ())
                     |}
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/src/assets/GetAsset.fs
+++ b/src/assets/GetAsset.fs
@@ -61,6 +61,6 @@ type GetAssetExtensions =
             | Ok asset ->
                 return asset
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/src/assets/GetAssets.fs
+++ b/src/assets/GetAssets.fs
@@ -195,6 +195,6 @@ type GetAssetsExtensions =
                         Items = assets.Items |> Seq.map (fun asset -> asset.ToPoco ())
                     |}
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/src/assets/GetAssetsByIds.fs
+++ b/src/assets/GetAssetsByIds.fs
@@ -88,7 +88,7 @@ type GetAssetsByIdsExtensions =
             | Ok assets ->
                 return assets |> Seq.map (fun asset -> asset.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }
 

--- a/src/assets/SearchAssets.fs
+++ b/src/assets/SearchAssets.fs
@@ -126,6 +126,6 @@ type SearchAssetsExtensions =
             | Ok assets ->
                 return assets |> Seq.map (fun asset -> asset.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/src/assets/UpdateAssets.fs
+++ b/src/assets/UpdateAssets.fs
@@ -160,6 +160,6 @@ type UpdateAssetsExtensions =
             | Ok response ->
                 return true
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/src/timeseries/CreateTimeseries.fs
+++ b/src/timeseries/CreateTimeseries.fs
@@ -81,6 +81,6 @@ type CreateTimeseriesExtensions =
             | Ok response ->
                 return response.Items |> Seq.map (fun ts -> ts.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/src/timeseries/DeleteTimeseries.fs
+++ b/src/timeseries/DeleteTimeseries.fs
@@ -72,6 +72,6 @@ type DeleteTimeseriesExtensions =
             | Ok response ->
                 return true
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/src/timeseries/GetAggregatedDataPoints.fs
+++ b/src/timeseries/GetAggregatedDataPoints.fs
@@ -291,7 +291,7 @@ type GetAggregatedDataPointsExtensions =
             | Ok response ->
                 return response |> Seq.map (fun points -> points.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }
 
@@ -310,7 +310,7 @@ type GetAggregatedDataPointsExtensions =
             | Ok response ->
                 return response |> Seq.map (fun points -> points.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }
 

--- a/src/timeseries/GetDataPoints.fs
+++ b/src/timeseries/GetDataPoints.fs
@@ -194,7 +194,7 @@ type GetDataPointsExtensions =
             | Ok response ->
                 return response |> Seq.map (fun points -> points.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }
 
@@ -213,7 +213,7 @@ type GetDataPointsExtensions =
             | Ok response ->
                 return response |> Seq.map (fun points -> points.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }
 

--- a/src/timeseries/GetLatestDataPoint.fs
+++ b/src/timeseries/GetLatestDataPoint.fs
@@ -116,7 +116,7 @@ type GetLatestDataPointExtensions =
             | Ok response ->
                 return response
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }
 

--- a/src/timeseries/GetTimeseries.fs
+++ b/src/timeseries/GetTimeseries.fs
@@ -112,6 +112,6 @@ type GetTimeseriesExtensions =
                         NextCursor = response.NextCursor
                     |}
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/src/timeseries/GetTimeseriesByIds.fs
+++ b/src/timeseries/GetTimeseriesByIds.fs
@@ -89,7 +89,7 @@ type GetTimeseriesByIdsExtensions =
             | Ok tss ->
                 return tss |> Seq.map (fun ts -> ts.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }
 

--- a/src/timeseries/InsertDataPoints.fs
+++ b/src/timeseries/InsertDataPoints.fs
@@ -95,7 +95,7 @@ type InsertDataExtensions =
             | Ok response ->
                 return true
             | Error error ->
-               let! err = error2Exception error
+               let err = error2Exception error
                return raise err
         }
 

--- a/src/timeseries/SearchTimeseries.fs
+++ b/src/timeseries/SearchTimeseries.fs
@@ -169,6 +169,6 @@ type SearchTimeseriesExtensions =
             | Ok tss ->
                 return tss |> Seq.map (fun ts -> ts.ToPoco ())
             | Error error ->
-                let! err = error2Exception error
+                let err = error2Exception error
                 return raise err
         }

--- a/test/integration/Assets.fs
+++ b/test/integration/Assets.fs
@@ -33,6 +33,26 @@ let ``Get assets with limit is Ok`` () = async {
 let ``Get asset by id is Ok`` () = async {
     // Arrange
     let ctx = readCtx ()
+    let assetId = 0L
+
+    // Act
+    let! res = getAssetAsync assetId ctx
+
+    let err =
+        match res.Result with
+        | Ok _ -> ResponseError.empty
+        | Error err -> err
+
+    // Assert
+    test <@ Result.isError res.Result @>
+    test <@ err.Code = 400 @>
+    test <@ err.Message = "getAsset.arg0: must be greater than or equal to 1" @>
+}
+
+[<Fact>]
+let ``Get asset by missing id is Error`` () = async {
+    // Arrange
+    let ctx = readCtx ()
     let assetId = 130452390632424L
 
     // Act
@@ -49,7 +69,6 @@ let ``Get asset by id is Ok`` () = async {
     test <@ res.Request.Method = RequestMethod.GET @>
     test <@ res.Request.Resource = "/assets/130452390632424" @>
 }
-
 
 [<Fact>]
 let ``Get asset by ids is Ok`` () = async {

--- a/test/integration/Timeseries.fs
+++ b/test/integration/Timeseries.fs
@@ -63,6 +63,26 @@ let ``Get timeseries by ids is Ok`` () = async {
 }
 
 [<Fact>]
+let ``Get timeseries by missing id is Error`` () = async {
+    // Arrange
+    let ctx = readCtx ()
+    let id = Identity.Id 0L
+
+    // Act
+    let! res = getTimeseriesByIdsAsync [ id ] ctx
+
+    let err =
+        match res.Result with
+        | Ok _ -> ResponseError.empty
+        | Error err -> err
+
+    // Assert
+    test <@ Result.isError res.Result @>
+    test <@ err.Code = 400 @>
+    test <@ err.Message = "timeseries ids not found: (id: 0 | externalId: null)" @>
+}
+
+[<Fact>]
 let ``Create and delete timeseries is Ok`` () = async {
     // Arrange
     let ctx = writeCtx ()

--- a/test/unit/csharp/Assets.cs
+++ b/test/unit/csharp/Assets.cs
@@ -138,7 +138,7 @@ namespace Tests
             };
 
             // Act/Assert
-            await Assert.ThrowsAsync<DecodeException>(() => client.GetAssetsAsync(assetArgs));
+            await Assert.ThrowsAsync<ResponseException>(() => client.GetAssetsAsync(assetArgs));
         }
 
         [Fact]
@@ -206,7 +206,7 @@ namespace Tests
                 .SetProject(project);
 
             // Act/Assert
-            await Assert.ThrowsAsync<DecodeException>(() => client.GetAssetAsync(42L));
+            await Assert.ThrowsAsync<ResponseException>(() => client.GetAssetAsync(42L));
         }
 
         [Fact]
@@ -439,7 +439,7 @@ namespace Tests
                 Client.Create(httpClient)
                 .AddHeader("api-key", apiKey)
                 .SetProject(project);
-            
+
             var options = new List<FilterAssets.Option> {
                 FilterAssets.Option.Limit(100),
                 FilterAssets.Option.Cursor("cursor")
@@ -479,7 +479,7 @@ namespace Tests
                 Client.Create(httpClient)
                 .AddHeader("api-key", apiKey)
                 .SetProject(project);
-            
+
             var createAssets = new List<AssetWritePoco>();
             for (int i = 0; i < 1000; i++) // 1000 is the maximum number of assets per request
             {
@@ -495,6 +495,6 @@ namespace Tests
             var result = await client.CreateAssetsAsync(createAssets);
             var refRequest = Encode.toString(0, new CreateAssets.AssetsCreateRequest(createAssets.Select(AssetWriteDto.FromPoco)).Encoder);
             Assert.Equal(refRequest, requestJson);
-        } 
+        }
     }
 }


### PR DESCRIPTION
Refactor error handling so we decode the error response to a record that matches what we get from the API.

Reduce the number of error types in the SDK to a single ResponseError so we don't first have to match Result and then ResponseError. Now ResponseError will contain everything.