### PR TITLE
Remove misleading bool return values

### DIFF
--- a/playground/csharp/Program.cs
+++ b/playground/csharp/Program.cs
@@ -66,7 +66,7 @@ namespace csharp
                     }
                 }
             };
-            var result2 = await client.InsertDataAsync(points);
+            await client.InsertDataAsync(points);
         }
 
         static async Task Main(string[] args)

--- a/src/Common.fs
+++ b/src/Common.fs
@@ -113,9 +113,9 @@ module Common =
         }
 
     /// Handler for disposing the stream when it's not needed anymore.
-    let dispose<'a> (next: NextHandler<bool,'a>) (context: Context<Stream>) =
+    let dispose<'a> (next: NextHandler<unit,'a>) (context: Context<Stream>) =
         async {
-            let nextResult = context.Result |> Result.map (fun stream -> stream.Dispose (); true)
+            let nextResult = context.Result |> Result.map (fun stream -> stream.Dispose ();)
             return! next { Request = context.Request; Result = nextResult }
         }
 

--- a/src/Fusion.fsproj
+++ b/src/Fusion.fsproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.8.7</Version>
-    <PackageVersion>0.8.7</PackageVersion>
+    <Version>0.8.8</Version>
+    <PackageVersion>0.8.8</PackageVersion>
     <PackageId>Fusion.NET</PackageId>
     <Company>Cognite AS</Company>
     <Copyright>Cognite AS</Copyright>

--- a/src/assets/DeleteAssets.fs
+++ b/src/assets/DeleteAssets.fs
@@ -53,10 +53,10 @@ module DeleteAssetsApi =
     /// **Output Type**
     ///   * `Async<Result<HttpResponse,ResponseError>>`
     ///
-    let deleteAssets (assets: Identity seq, recursive: bool) (next: NextHandler<bool,'a>) =
+    let deleteAssets (assets: Identity seq, recursive: bool) (next: NextHandler<unit,'a>) =
         DeleteAssets.deleteAssets (assets, recursive) fetch next
 
-    let deleteAssetsAsync<'a> (assets: Identity seq, recursive: bool) : HttpContext -> Async<Context<bool>> =
+    let deleteAssetsAsync<'a> (assets: Identity seq, recursive: bool) : HttpContext -> Async<Context<unit>> =
         DeleteAssets.deleteAssets (assets, recursive) fetch Async.single
 
 [<Extension>]
@@ -72,8 +72,7 @@ type DeleteAssetsExtensions =
         task {
             let! ctx = deleteAssetsAsync (ids, recursive) this.Ctx
             match ctx.Result with
-            | Ok response ->
-                return ()
+            | Ok _ -> return ()
             | Error error ->
                 let err = error2Exception error
                 return raise err

--- a/src/assets/FilterAssets.fs
+++ b/src/assets/FilterAssets.fs
@@ -53,6 +53,7 @@ module FilterAssets =
             Filters = filters
             Options = options
         }
+        request.Encoder |> Encode.stringify |> printfn "%A"
 
         POST
         >=> setVersion V10

--- a/src/timeseries/DeleteTimeseries.fs
+++ b/src/timeseries/DeleteTimeseries.fs
@@ -27,7 +27,7 @@ module DeleteTimeseries =
                 yield ("items", Seq.map (fun (it: Identity) -> it.Encoder) this.Items |> Encode.seq)
             ]
 
-    let deleteTimeseries (items: Identity seq) (fetch: HttpHandler<HttpResponseMessage, Stream, bool>) =
+    let deleteTimeseries (items: Identity seq) (fetch: HttpHandler<HttpResponseMessage, Stream, unit>) =
         let request : DeleteRequest = { Items = items }
         let body = Encode.stringify request.Encoder
 
@@ -51,7 +51,7 @@ module DeleteTimeseriesApi =
     /// **Output Type**
     ///   * `Async<Result<HttpResponse,ResponseError>>`
     ///
-    let deleteTimeseries (items: Identity seq) (next: NextHandler<bool, bool>) =
+    let deleteTimeseries (items: Identity seq) (next: NextHandler<unit, unit>) =
         DeleteTimeseries.deleteTimeseries items fetch next
 
     let deleteTimeseriesAsync (items: Identity seq) =
@@ -65,13 +65,12 @@ type DeleteTimeseriesExtensions =
     /// <param name="name">The name of the timeseries to delete.</param>
     /// <returns>List of created timeseries.</returns>
     [<Extension>]
-    static member DeleteTimeseriesAsync (this: Client) (items: Identity seq) : Task<bool> =
+    static member DeleteTimeseriesAsync (this: Client) (items: Identity seq) : Task =
         task {
             let! ctx = deleteTimeseriesAsync items this.Ctx
             match ctx.Result with
-            | Ok response ->
-                return true
+            | Ok _ -> return ()
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } :> Task

--- a/src/timeseries/InsertDataPoints.fs
+++ b/src/timeseries/InsertDataPoints.fs
@@ -38,7 +38,7 @@ module InsertDataPoints =
                 yield ("items", Seq.map (fun (it: DataPoints) -> it.Encoder) this.Items |> Encode.seq)
             ]
 
-    let insertDataPoints (items: seq<DataPoints>) (fetch: HttpHandler<HttpResponseMessage, Stream, bool>) =
+    let insertDataPoints (items: seq<DataPoints>) (fetch: HttpHandler<HttpResponseMessage, Stream, unit>) =
         let request : PointRequest = { Items = items }
         let body = Encode.stringify request.Encoder
 
@@ -65,7 +65,7 @@ module InsertDataPointsApi =
     /// **Output Type**
     ///   * `Async<Result<HttpResponse,ResponseError>>`
     ///
-    let insertDataPoints (items: InsertDataPoints.DataPoints list) (next: NextHandler<bool,bool>) =
+    let insertDataPoints (items: InsertDataPoints.DataPoints list) (next: NextHandler<unit,unit>) =
         InsertDataPoints.insertDataPoints items fetch next
 
     let insertDataPointsAsync (items: seq<InsertDataPoints.DataPoints>) =
@@ -80,7 +80,7 @@ type InsertDataExtensions =
     /// <param name="items">The list of data points to insert.</param>
     /// <returns>True if successful.</returns>
     [<Extension>]
-    static member InsertDataAsync (this: Client) (items: DataPointsWritePoco seq) : Task<bool> =
+    static member InsertDataAsync (this: Client) (items: DataPointsWritePoco seq) : Task =
         let items' =
             Seq.map  (fun (item: DataPointsWritePoco) ->
                 {
@@ -92,11 +92,10 @@ type InsertDataExtensions =
         task {
             let! ctx = insertDataPointsAsync items' this.Ctx
             match ctx.Result with
-            | Ok response ->
-                return true
+            | Ok _ -> return ()
             | Error error ->
                let err = error2Exception error
                return raise err
-        }
+        } :> Task
 
 

--- a/test/integration/Assets.fs
+++ b/test/integration/Assets.fs
@@ -220,7 +220,7 @@ let ``Update assets is Ok`` () = async {
 
     let updateSuccsess =
         match updateRes.Result with
-        | Ok res -> res
+        | Ok res -> true
         | Error _ -> false
 
     // Assert create

--- a/test/unit/csharp/Assets.cs
+++ b/test/unit/csharp/Assets.cs
@@ -290,10 +290,7 @@ namespace Tests
             };
 
             // Act
-            var result = await client.UpdateAssetsAsync(assets);
-
-            // Assert
-            Assert.True(result);
+            await client.UpdateAssetsAsync(assets);
         }
 
         [Fact]


### PR DESCRIPTION
Bool as return implies that a failed insertion will result in false. This is not the case for us, in fact, false as a return value is impossible.

This commit changes the return to unit for F# or Task for C#. Empty return implies that there is no return value, and that a failure will result
in either an Error type for F# or an exception for C# like everything else in the SDK.

In UpdateAssets the return value is actually the same as in CreateAssets, the complete list of changed assets, so there bool was changed to that instead.

I actually made this mistake myself when using the SDK. A bool that can only ever be true should not be a bool.