### PR TITLE
Fix multi project nuget

### DIFF
--- a/Fusion.NET.sln
+++ b/Fusion.NET.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fusion", "src\Fusion.fsproj", "{71D7712C-6ED2-4E70-AEA4-54FA149149C9}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fusion", "src\Fusion.NET.fsproj", "{71D7712C-6ED2-4E70-AEA4-54FA149149C9}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{D6594809-62AA-416C-AA3E-D289963F012E}"
 EndProject

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,8 @@ podTemplate(
         container('dotnet-mono') {
           stage('Install dependencies') {
             sh('mono .paket/paket.exe install')
+            // Download the latest stable `nuget.exe` to `/usr/local/bin`
+            sh('curl -o /usr/local/bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe')
           }
 
           stage('Build') {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-dotnet pack -c release
-dotnet nuget push src/bin/Release/*.nupkg -s https://cognite.jfrog.io/cognite/api/nuget/nuget-local
+mono /usr/local/bin/nuget.exe pack src/Fusion.NET.fsproj -IncludeReferencedProjects
+dotnet nuget push *.nupkg -s https://cognite.jfrog.io/cognite/api/nuget/nuget-local

--- a/playground/csharp/App.csproj
+++ b/playground/csharp/App.csproj
@@ -6,7 +6,9 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../../src/Fusion.fsproj" />
+    <ProjectReference Include="../../protobuf/proto.csproj" />
+    <ProjectReference Include="../../src/Fusion.NET.fsproj" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
+
 </Project>

--- a/playground/fsharp/App.fsproj
+++ b/playground/fsharp/App.fsproj
@@ -8,7 +8,8 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../src/Fusion.fsproj" />
+    <ProjectReference Include="../../protobuf/proto.csproj" />
+    <ProjectReference Include="../../src/Fusion.NET.fsproj" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Fusion.NET.fsproj
+++ b/src/Fusion.NET.fsproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Description>.NET SDK for Cognite Data Fusion (CDF)</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.8.12</Version>
-    <PackageVersion>0.8.12</PackageVersion>
+    <Version>0.8.13</Version>
+    <PackageVersion>0.8.13</PackageVersion>
     <PackageId>Fusion.NET</PackageId>
+    <Author>Cognite AS</Author>
     <Company>Cognite AS</Company>
     <Copyright>Cognite AS</Copyright>
   </PropertyGroup>

--- a/test/integration/Test.Integration.fsproj
+++ b/test/integration/Test.Integration.fsproj
@@ -15,7 +15,8 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Fusion.fsproj" />
+    <ProjectReference Include="../../protobuf/proto.csproj" />
+    <ProjectReference Include="../../src\Fusion.NET.fsproj" />
   </ItemGroup>
 
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/test/unit/csharp/Test.Unit.csproj
+++ b/test/unit/csharp/Test.Unit.csproj
@@ -13,7 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Fusion.fsproj" />
+    <ProjectReference Include="../../../protobuf/proto.csproj" />
+    <ProjectReference Include="../../../src/Fusion.NET.fsproj" />
   </ItemGroup>
 
   <Import Project="..\..\..\.paket\Paket.Restore.targets" />

--- a/test/unit/fsharp/Test.Unit.fsproj
+++ b/test/unit/fsharp/Test.Unit.fsproj
@@ -20,7 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Fusion.fsproj" />
+    <ProjectReference Include="../../../protobuf/proto.csproj" />
+    <ProjectReference Include="../../../src/Fusion.NET.fsproj" />
   </ItemGroup>
 
   <Import Project="..\..\..\.paket\Paket.Restore.targets" />


### PR DESCRIPTION
The problem is that `dotnet pack` does not bundle the binaries of project references. To fix this we need to either 1) make a nuget of the proto project or 2) use `nuget.exe` instead of `dotnet pack`. 

Rename the project file to get the nuget package right. Include proto in all other projects as well.