### PR TITLE
Hide union in GetLatestDataPoint

### DIFF
--- a/src/Fusion.NET.fsproj
+++ b/src/Fusion.NET.fsproj
@@ -3,8 +3,8 @@
     <Description>.NET SDK for Cognite Data Fusion (CDF)</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.8.14</Version>
-    <PackageVersion>0.8.14</PackageVersion>
+    <Version>0.8.15</Version>
+    <PackageVersion>0.8.15</PackageVersion>
     <PackageId>Fusion.NET</PackageId>
     <Author>Cognite AS</Author>
     <Company>Cognite AS</Company>


### PR DESCRIPTION
There was an exposed union in C# which should be hidden. This is one solution, the alternative is serializing to the protobuf types, though that may be a little misleading, as the response here is json only.