### PR TITLE
Use tags for versioning.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,29 @@ for safer force pushing.
 Also make sure master is up to date.
 
 Since we are force pushing, you should never push to master or to someone elses branch.
+
+## Releasing
+
+We use tags for versioning, the tag name needs to be a [legal nuget version number](https://docs.microsoft.com/en-us/nuget/reference/package-versioning)
+e.g. 0.9.7 or 1.13.15.
+
+To create new tags either do:
+
+1. `git tag -a [tag name] -m [tag description]`
+2. `git push origin [tag name]`
+
+or use the "Releases" tab on github to add a tag.
+
+Tags are not pushed by default, though you can use `git push --tags` in order to push tags,
+make sure you do not push local tags unintentionally.
+
+Tags are unique, and map directly to the semantic versioning number in nuget.
+
+There will always be a build, if there is no specific tag for the commit in question, a tag will be generated on the form
+
+`[latest tag in history]-build.[commits since last tag]`
+
+You might have to restart the build in jenkins to deploy a build that already built without tag.
+
+Note that tags are connected to commits, but if you create a merge commit merging into master then git may try to generate a new tag for you.
+The easiest solution is to only tag master.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,9 @@ podTemplate(
                 ])
 
                 gitCommit = sh(returnStdout: true, script: 'git rev-parse --short=12 HEAD').trim()
+                version = sh(returnStdout: true, script: "git describe --tags HEAD || true").trim()
+                version = version.replaceFirst(/-(\d+)-.*/, '-build.$1')
+                print version
             }
         }
 
@@ -94,7 +97,7 @@ podTemplate(
 
           stage("Deploy package to registry") {
             if (env.BRANCH_NAME == 'master') {
-              sh('./deploy.sh')
+              sh("./deploy.sh ${version}")
             }
           }
         }

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-dotnet pack -c release
+dotnet pack -c release -p:PackageVersion=$1
 dotnet nuget push src/bin/Release/*.nupkg -s https://cognite.jfrog.io/cognite/api/nuget/nuget-local

--- a/src/Fusion.NET.fsproj
+++ b/src/Fusion.NET.fsproj
@@ -3,8 +3,6 @@
     <Description>.NET SDK for Cognite Data Fusion (CDF)</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.8.17</Version>
-    <PackageVersion>0.8.17</PackageVersion>
     <PackageId>Fusion.NET</PackageId>
     <Author>Cognite AS</Author>
     <Company>Cognite AS</Company>


### PR DESCRIPTION
This means that in order to push to artifactory, you need to create a
tag on the commit to build, then push it to master. Note that tags are
not pushed by default, the correct way to do it is
`git push origin [tagname]`

Resolves #68 