### PR TITLE
Add cancellation token support for c# interop

### DIFF
--- a/src/assets/CreateAssets.fs
+++ b/src/assets/CreateAssets.fs
@@ -4,14 +4,15 @@ open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
 open Fusion.Api
 open Fusion.Common
 open Fusion.Assets
+open System.Threading
 
 
 [<RequireQualifiedAccess>]
@@ -73,8 +74,8 @@ type CreateAssetsExtensions =
     /// <param name="assets">The assets to create.</param>
     /// <returns>List of created assets.</returns>
     [<Extension>]
-    static member CreateAssetsAsync (this: Client, assets: AssetWritePoco seq) : Task<AssetReadPoco seq> =
-        task {
+    static member CreateAssetsAsync (this: Client, assets: AssetWritePoco seq, [<Optional>] token: CancellationToken) : Task<AssetReadPoco seq> =
+        async {
             let assets' = assets |> Seq.map AssetWriteDto.FromPoco
             let! ctx = createAssetsAsync assets' this.Ctx
             match ctx.Result with
@@ -83,4 +84,4 @@ type CreateAssetsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)

--- a/src/assets/DeleteAssets.fs
+++ b/src/assets/DeleteAssets.fs
@@ -3,14 +3,15 @@
 open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
 open System.Threading.Tasks
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
 open Fusion.Api
 open Fusion.Common
+open System.Threading
 
 [<RequireQualifiedAccess>]
 module DeleteAssets =
@@ -67,13 +68,13 @@ type DeleteAssetsExtensions =
     /// <param name="assets">The list of assets to delete.</param>
     /// <param name="recursive">If true, delete all children recursively.</param>
     [<Extension>]
-    static member DeleteAssetsAsync(this: Client, ids: Identity seq, recursive: bool) : Task =
-        task {
+    static member DeleteAssetsAsync(this: Client, ids: Identity seq, recursive: bool, [<Optional>] token: CancellationToken) : Task =
+        async {
             let! ctx = deleteAssetsAsync (ids, recursive) this.Ctx
             match ctx.Result with
             | Ok _ -> return ()
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        } :> Task
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token) :> Task
 

--- a/src/assets/FilterAssets.fs
+++ b/src/assets/FilterAssets.fs
@@ -3,14 +3,15 @@
 open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
 open Fusion.Api
 open Fusion.Common
 open Fusion.Assets
+open System.Threading
 
 [<RequireQualifiedAccess>]
 module FilterAssets =
@@ -92,8 +93,8 @@ type FilterAssetsExtensions =
     /// <param name="filters">Search filters</param>
     /// <returns>List of assets matching given filters and optional cursor</returns>
     [<Extension>]
-    static member FilterAssetsAsync (this: Client, options: FilterAssets.Option seq, filters: AssetFilter seq) =
-        task {
+    static member FilterAssetsAsync (this: Client, options: FilterAssets.Option seq, filters: AssetFilter seq, [<Optional>] token: CancellationToken) =
+        async {
             let! ctx = filterAssetsAsync options filters this.Ctx
             match ctx.Result with
             | Ok assets ->
@@ -104,4 +105,4 @@ type FilterAssetsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)

--- a/src/assets/GetAsset.fs
+++ b/src/assets/GetAsset.fs
@@ -3,14 +3,14 @@ namespace Fusion
 open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
 open System.Threading.Tasks
-
-open FSharp.Control.Tasks.V2.ContextInsensitive
 
 open Fusion
 open Fusion.Common
 open Fusion.Api
 open Fusion.Assets
+open System.Threading
 
 [<RequireQualifiedAccess>]
 module GetAsset =
@@ -54,8 +54,8 @@ type GetAssetExtensions =
     /// <param name="assetId">The id of the asset to get.</param>
     /// <returns>Asset with the given id.</returns>
     [<Extension>]
-    static member GetAssetAsync (this: Client, assetId: int64) : Task<AssetReadDto> =
-        task {
+    static member GetAssetAsync (this: Client, assetId: int64, [<Optional>] token: CancellationToken) : Task<AssetReadDto> =
+        async {
             let! ctx = getAssetAsync assetId this.Ctx
             match ctx.Result with
             | Ok asset ->
@@ -63,4 +63,4 @@ type GetAssetExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)

--- a/src/assets/GetAssets.fs
+++ b/src/assets/GetAssets.fs
@@ -4,6 +4,8 @@ open System
 open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
 
 open FSharp.Control.Tasks.V2.ContextInsensitive
 open Thoth.Json.Net
@@ -167,8 +169,8 @@ type GetAssetsExtensions =
     /// <param name="args">The asset argument object containing parameters to get used for the asset query.</param>
     /// <returns>List of assets and optional cursor.</returns>
     [<Extension>]
-    static member GetAssetsAsync (this: Client, args: GetAssets.Option seq) =
-        task {
+    static member GetAssetsAsync (this: Client, args: GetAssets.Option seq, [<Optional>] token: CancellationToken) =
+        async {
             let! ctx = getAssetsAsync args this.Ctx
             match ctx.Result with
             | Ok assets ->
@@ -179,4 +181,4 @@ type GetAssetsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)

--- a/src/assets/GetAssetsByIds.fs
+++ b/src/assets/GetAssetsByIds.fs
@@ -4,6 +4,8 @@ open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
 open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
@@ -79,8 +81,8 @@ type GetAssetsByIdsExtensions =
     /// <param name="assetId">The ids of the assets to get.</param>
     /// <returns>Assets with given ids.</returns>
     [<Extension>]
-    static member GetAssetsByIdsAsync (this: Client, ids: seq<Identity>) : Task<_ seq> =
-        task {
+    static member GetAssetsByIdsAsync (this: Client, ids: seq<Identity>, [<Optional>] token: CancellationToken) : Task<_ seq> =
+        async {
             let! ctx = getAssetsByIdsAsync ids this.Ctx
             match ctx.Result with
             | Ok assets ->
@@ -88,7 +90,7 @@ type GetAssetsByIdsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)
 
 
 

--- a/src/assets/SearchAssets.fs
+++ b/src/assets/SearchAssets.fs
@@ -4,6 +4,8 @@ open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
 open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
@@ -111,8 +113,8 @@ type SearchAssetsExtensions =
     ///
     /// <returns>List of assets matching given criteria.</returns>
     [<Extension>]
-    static member SearchAssetsAsync (this: Client, limit : int, options: SearchAssets.Option seq, filters: AssetFilter seq) : Task<_ seq> =
-        task {
+    static member SearchAssetsAsync (this: Client, limit : int, options: SearchAssets.Option seq, filters: AssetFilter seq, [<Optional>] token: CancellationToken) : Task<_ seq> =
+        async {
             let! ctx = searchAssetsAsync limit options filters this.Ctx
             match ctx.Result with
             | Ok assets ->
@@ -120,4 +122,4 @@ type SearchAssetsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask (op, cancellationToken = token)

--- a/src/timeseries/CreateTimeseries.fs
+++ b/src/timeseries/CreateTimeseries.fs
@@ -1,12 +1,12 @@
 namespace Fusion
 
-open System
 open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
@@ -73,8 +73,8 @@ type CreateTimeseriesExtensions =
     /// <param name="items">The list of timeseries to create.</param>
     /// <returns>List of created timeseries.</returns>
     [<Extension>]
-    static member CreateTimeseriesAsync (this: Client) (items: seq<TimeseriesWritePoco>) : Task<TimeseriesReadPoco seq> =
-        task {
+    static member CreateTimeseriesAsync (this: Client, items: seq<TimeseriesWritePoco>, [<Optional>] token: CancellationToken) : Task<TimeseriesReadPoco seq> =
+        async {
             let items' = items |> Seq.map TimeseriesWriteDto.FromPoco
             let! ctx = createTimeseriesAsync items' this.Ctx
             match ctx.Result with
@@ -83,4 +83,4 @@ type CreateTimeseriesExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)

--- a/src/timeseries/DeleteDataPoints.fs
+++ b/src/timeseries/DeleteDataPoints.fs
@@ -4,8 +4,9 @@ open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
@@ -88,8 +89,8 @@ type DeleteDataPointsExtensions =
     /// </summary>
     /// <param name = "items">List of delete requests.</param>
     [<Extension>]
-    static member DeleteDataPointsAsync (this: Client) (items: DeleteDataPoints.DeleteRequestPoco seq) : Task =
-        task {
+    static member DeleteDataPointsAsync (this: Client, items: DeleteDataPoints.DeleteRequestPoco seq, [<Optional>] token: CancellationToken) : Task =
+        async {
             let items' = items |> Seq.map DeleteDataPoints.DeleteRequestDto.FromPoco
             let! ctx = deleteDataPointsAsync items' this.Ctx
             match ctx.Result with
@@ -97,4 +98,4 @@ type DeleteDataPointsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        } :> Task
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token) :> Task

--- a/src/timeseries/DeleteTimeseries.fs
+++ b/src/timeseries/DeleteTimeseries.fs
@@ -4,8 +4,9 @@ open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
@@ -59,12 +60,12 @@ type DeleteTimeseriesExtensions =
     /// </summary>
     /// <param name="items">List of timeseries ids to delete.</param>
     [<Extension>]
-    static member DeleteTimeseriesAsync (this: Client) (items: Identity seq) : Task =
-        task {
+    static member DeleteTimeseriesAsync (this: Client, items: Identity seq, [<Optional>] token: CancellationToken) : Task =
+        async {
             let! ctx = deleteTimeseriesAsync items this.Ctx
             match ctx.Result with
             | Ok _ -> return ()
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        } :> Task
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token) :> Task

--- a/src/timeseries/GetAggregatedDataPoints.fs
+++ b/src/timeseries/GetAggregatedDataPoints.fs
@@ -1,12 +1,12 @@
 namespace Fusion
 
-open System
 open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
@@ -296,8 +296,8 @@ type GetAggregatedDataPointsExtensions =
     /// <param name="options">Options describing a query for datapoints.</param>
     /// <returns>List of aggregated data points.</returns>
     [<Extension>]
-    static member GetAggregatedDataPointsAsync (this: Client, id : Identity, options: GetAggregatedDataPoints.QueryOption seq) : Task<DataPointListResponse> =
-        task {
+    static member GetAggregatedDataPointsAsync (this: Client, id : Identity, options: GetAggregatedDataPoints.QueryOption seq, [<Optional>] token: CancellationToken) : Task<DataPointListResponse> =
+        async {
             let! ctx = getAggregatedDataPointsProto id options this.Ctx
             match ctx.Result with
             | Ok response ->
@@ -305,7 +305,7 @@ type GetAggregatedDataPointsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)
 
     /// <summary>
     /// Retrieves a list of aggregated data points from multiple time series in the same project.
@@ -315,8 +315,8 @@ type GetAggregatedDataPointsExtensions =
     /// datapoint query items are omitted, top-level values are used instead.</param>
     /// <returns>List of aggregated data points.</returns>
     [<Extension>]
-    static member GetAggregatedDataPointsMultipleAsync (this: Client, options: GetAggregatedDataPoints.Option seq, defaultOptions: GetAggregatedDataPoints.QueryOption seq) : Task<DataPointListResponse> =
-        task {
+    static member GetAggregatedDataPointsMultipleAsync (this: Client, options: GetAggregatedDataPoints.Option seq, defaultOptions: GetAggregatedDataPoints.QueryOption seq, [<Optional>] token: CancellationToken) : Task<DataPointListResponse> =
+        async {
             let! ctx = getAggregatedDataPointsMultipleProto options defaultOptions this.Ctx
             match ctx.Result with
             | Ok response ->
@@ -324,5 +324,5 @@ type GetAggregatedDataPointsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)
 

--- a/src/timeseries/GetDataPoints.fs
+++ b/src/timeseries/GetDataPoints.fs
@@ -1,12 +1,12 @@
 namespace Fusion
 
-open System
 open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
@@ -200,8 +200,8 @@ type GetDataPointsExtensions =
     /// <param name="options">Options describing a query for datapoints.</param>
     /// <returns>A single datapoint response object containing a list of datapoints.</returns>
     [<Extension>]
-    static member GetDataPointsAsync (this: Client, id : int64, options: GetDataPoints.QueryOption seq) : Task<DataPointListResponse> =
-        task {
+    static member GetDataPointsAsync (this: Client, id : int64, options: GetDataPoints.QueryOption seq, [<Optional>] token: CancellationToken) : Task<DataPointListResponse> =
+        async {
             let! ctx = getDataPointsProto id options this.Ctx
             match ctx.Result with
             | Ok response ->
@@ -209,7 +209,7 @@ type GetDataPointsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)
 
     /// <summary>
     /// Retrieves a list of data points from multiple time series in the same project.
@@ -219,8 +219,8 @@ type GetDataPointsExtensions =
     /// datapoint query items are omitted, top-level values are used instead.</param>
     /// <returns>List of datapoint responses containing lists of datapoints for each timeseries.</returns>
     [<Extension>]
-    static member GetDataPointsMultipleAsync (this: Client, options: GetDataPoints.Option seq, defaultOptions: GetDataPoints.QueryOption seq) : Task<DataPointListResponse> =
-        task {
+    static member GetDataPointsMultipleAsync (this: Client, options: GetDataPoints.Option seq, defaultOptions: GetDataPoints.QueryOption seq, [<Optional>] token: CancellationToken) : Task<DataPointListResponse> =
+        async {
             let! ctx = getDataPointsMultipleProto options defaultOptions this.Ctx
             match ctx.Result with
             | Ok response ->
@@ -228,5 +228,5 @@ type GetDataPointsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)
 

--- a/src/timeseries/GetLatestDataPoint.fs
+++ b/src/timeseries/GetLatestDataPoint.fs
@@ -5,8 +5,9 @@ open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
@@ -131,8 +132,8 @@ type GetLatestDataPointExtensions =
     /// <param name="options">List of tuples (id, beforeString) where beforeString describes the latest point to look for datapoints.</param>
     /// <returns>List of results containing the latest datapoint and ids.</returns>
     [<Extension>]
-    static member GetLatestDataPointAsync (this: Client) (options: ValueTuple<Identity, string> seq) : Task<seq<GetLatestDataPoint.DataPointsPoco>> =
-        task {
+    static member GetLatestDataPointAsync (this: Client, options: ValueTuple<Identity, string> seq, [<Optional>] token: CancellationToken) : Task<seq<GetLatestDataPoint.DataPointsPoco>> =
+        async {
             let query = options |> Seq.map (fun struct (id, before) ->
                 { Identity = id;
                   Before = if (isNull before) then None else Some before
@@ -144,5 +145,5 @@ type GetLatestDataPointExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)
 

--- a/src/timeseries/GetTimeseries.fs
+++ b/src/timeseries/GetTimeseries.fs
@@ -5,8 +5,9 @@ open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
@@ -107,8 +108,8 @@ type GetTimeseriesExtensions =
     /// <param name="options">Timeseries lookup options.</param>
     /// <returns>The timeseries with the given id and an optional cursor.</returns>
     [<Extension>]
-    static member GetTimeseriesAsync (this: Client) (options: GetTimeseries.Option seq) : Task<_> =
-        task {
+    static member GetTimeseriesAsync (this: Client, options: GetTimeseries.Option seq, [<Optional>] token: CancellationToken) : Task<_> =
+        async {
             let! ctx = getTimeseriesAsync options this.Ctx
 
             match ctx.Result with
@@ -120,4 +121,4 @@ type GetTimeseriesExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)

--- a/src/timeseries/GetTimeseriesByIds.fs
+++ b/src/timeseries/GetTimeseriesByIds.fs
@@ -4,8 +4,9 @@ open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
@@ -83,8 +84,8 @@ type GetTimeseriesByIdsExtensions =
     /// <param name="ids">The ids of the timeseries to get.</param>
     /// <returns>The timeseries with the given ids.</returns>
     [<Extension>]
-    static member GetTimeseriesByIdsAsync (this: Client, ids: seq<Identity>) : Task<seq<_>> =
-        task {
+    static member GetTimeseriesByIdsAsync (this: Client, ids: seq<Identity>, [<Optional>] token: CancellationToken) : Task<seq<_>> =
+        async {
             let! ctx = getTimeseriesByIdsAsync ids this.Ctx
 
             match ctx.Result with
@@ -93,7 +94,7 @@ type GetTimeseriesByIdsExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)
 
 
 

--- a/src/timeseries/InsertDataPoints.fs
+++ b/src/timeseries/InsertDataPoints.fs
@@ -4,9 +4,8 @@ open System.IO
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
-
-open FSharp.Control.Tasks.V2
-open Thoth.Json.Net
+open System.Runtime.InteropServices
+open System.Threading
 
 open Fusion
 open Fusion.Api
@@ -96,14 +95,14 @@ type InsertDataExtensions =
     /// </summary>
     /// <param name="items">The list of datapoint insertion requests.</param>
     [<Extension>]
-    static member InsertDataAsync (this: Client) (items: DataPointInsertionRequest) : Task =
-        task {
+    static member InsertDataAsync (this: Client, items: DataPointInsertionRequest, [<Optional>] token: CancellationToken) : Task =
+        async {
             let! ctx = insertDataPointsAsyncProto items this.Ctx
             match ctx.Result with
             | Ok _ -> return ()
             | Error error ->
                let err = error2Exception error
                return raise err
-        } :> Task
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token):> Task
 
 

--- a/src/timeseries/SearchTimeseries.fs
+++ b/src/timeseries/SearchTimeseries.fs
@@ -5,8 +5,9 @@ open System.Collections.Generic
 open System.Net.Http
 open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
-open FSharp.Control.Tasks.V2
 open Thoth.Json.Net
 
 open Fusion
@@ -154,8 +155,8 @@ type SearchTimeseriesExtensions =
     /// <param name="filters">Search filters.</param>
     /// <returns>Timeseries matching query.</returns>
     [<Extension>]
-    static member SearchTimeseriesAsync (this: Client, limit : int, options: SearchTimeseries.Option seq, filters: SearchTimeseries.Filter seq) : Task<_ seq> =
-        task {
+    static member SearchTimeseriesAsync (this: Client, limit : int, options: SearchTimeseries.Option seq, filters: SearchTimeseries.Filter seq, [<Optional>] token: CancellationToken) : Task<_ seq> =
+        async {
             let! ctx = searchTimeseriesAsync limit options filters this.Ctx
             match ctx.Result with
             | Ok tss ->
@@ -163,4 +164,4 @@ type SearchTimeseriesExtensions =
             | Error error ->
                 let err = error2Exception error
                 return raise err
-        }
+        } |> fun op -> Async.StartAsTask(op, cancellationToken = token)


### PR DESCRIPTION
Added as an optional argument to all c# methods, f# automatically
handles cancellationTokens in async context, so all we need to do to
support it from c# is to add it manually when building tasks for c#.