### PR TITLE
Add ReturnFrom to the computational expression builder

### DIFF
--- a/src/Builder.fs
+++ b/src/Builder.fs
@@ -1,7 +1,5 @@
 namespace Fusion
 
-//open FSharp.Data
-open System.Net
 open System.Net.Http
 
 type RequestBuilder () =
@@ -9,6 +7,8 @@ type RequestBuilder () =
     member this.Return (res: 'a) : HttpHandler<HttpResponseMessage, 'a, _> = fun next _ ->  next { Request = defaultRequest; Result = Ok res }
 
     member this.Return (req: HttpRequest) : HttpHandler<HttpResponseMessage, HttpResponseMessage, _> = fun next ctx -> next { Request = req; Result = defaultResult }
+
+    member this.ReturnFrom (req : HttpHandler<'a, 'b, 'c>)  : HttpHandler<'a, 'b, 'c>  = req
 
     member this.Delay (fn) = fn ()
 

--- a/src/Common.fs
+++ b/src/Common.fs
@@ -113,18 +113,14 @@ module Common =
         }
     let decodeProtobuf<'b, 'c> (parser : Stream -> 'b) (next: NextHandler<'b, 'c>) (context : Context<Stream>) =
         async {
-            let result = context.Result
-            let nextResult =
-                match result with
-                | Ok stream -> Ok (parser stream)
-                | Error err -> Error err
-            return! next { Request = context.Request; Result = nextResult }
+            let result = context.Result |> Result.map parser
+            return! next { Request = context.Request; Result = result }
         }
 
     /// Handler for disposing the stream when it's not needed anymore.
     let dispose<'a> (next: NextHandler<unit,'a>) (context: Context<Stream>) =
         async {
-            let nextResult = context.Result |> Result.map (fun stream -> stream.Dispose ();)
+            let nextResult = context.Result |> Result.map (fun stream -> stream.Dispose ())
             return! next { Request = context.Request; Result = nextResult }
         }
 

--- a/src/assets/GetAssets.fs
+++ b/src/assets/GetAssets.fs
@@ -14,6 +14,7 @@ open Fusion
 open Fusion.Common
 open Fusion.Api
 open Fusion.Assets
+open System.Threading
 
 [<RequireQualifiedAccess>]
 module GetAssets =
@@ -137,7 +138,7 @@ module GetAssets =
 module GetAssetsApi =
     /// <summary>
     /// List all assets in the given project. If given limit or 1000 results are exceeded, return a cursor to paginate through results.
-    /// 
+    ///
     /// You can retrieve a subset of assets by supplying additional fields; Only assets satisfying all criteria will be
     /// returned.
     /// </summary>
@@ -149,7 +150,7 @@ module GetAssetsApi =
 
     /// <summary>
     /// List all assets in the given project. If given limit or 1000 results are exceeded, return a cursor to paginate through results.
-    /// 
+    ///
     /// You can retrieve a subset of assets by supplying additional fields; Only assets satisfying all criteria will be
     /// returned.
     /// </summary>
@@ -162,7 +163,7 @@ module GetAssetsApi =
 type GetAssetsExtensions =
     /// <summary>
     /// List all assets in the given project. If given limit or 1000 results are exceeded, return a cursor to paginate through results.
-    /// 
+    ///
     /// You can retrieve a subset of assets by supplying additional fields; Only assets satisfying all criteria will be
     /// returned.
     /// </summary>


### PR DESCRIPTION
- Simplify result matching by using Result.map
- Remove trailing spaces
- Add unit tests for builder