### PR TITLE
Adjust namespaces

### DIFF
--- a/src/assets/CreateAssets.fs
+++ b/src/assets/CreateAssets.fs
@@ -2,6 +2,10 @@ namespace CogniteSdk.Assets
 
 open System.IO
 open System.Net.Http
+open System.Runtime.InteropServices
+open System.Runtime.CompilerServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
@@ -57,17 +61,6 @@ module Create =
     /// <returns>List of created assets.</returns>
     let createAsync (assets: AssetWriteDto seq) =
         createCore assets fetch Async.single
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-
-
-open Oryx
-open CogniteSdk.Assets
 
 [<Extension>]
 type CreateAssetsExtensions =

--- a/src/assets/DeleteAssets.fs
+++ b/src/assets/DeleteAssets.fs
@@ -2,6 +2,10 @@
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
@@ -53,15 +57,6 @@ module Delete =
     let deleteAsync<'a> (assets: Identity seq, recursive: bool) : HttpContext -> Async<Context<unit>> =
         deleteCore (assets, recursive) fetch Async.single
 
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-
-open Oryx
-open CogniteSdk.Assets
 
 [<Extension>]
 type DeleteAssetsExtensions =

--- a/src/assets/FilterAssets.fs
+++ b/src/assets/FilterAssets.fs
@@ -2,7 +2,9 @@
 
 open System.IO
 open System.Net.Http
-
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
 
 open Oryx
 open Thoth.Json.Net
@@ -80,16 +82,6 @@ module Filter =
         : HttpContext -> Async<Context<Assets.AssetListResponse>> =
             filterCore options filters fetch Async.single
 
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Runtime.InteropServices
-open System.Threading
-
-
-open Oryx
-open CogniteSdk.Assets
 
 [<Extension>]
 type FilterAssetsExtensions =

--- a/src/assets/GetAsset.fs
+++ b/src/assets/GetAsset.fs
@@ -2,8 +2,14 @@ namespace CogniteSdk.Assets
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
+open CogniteSdk.Assets
+
 open CogniteSdk
 
 
@@ -38,16 +44,6 @@ module Single =
     /// <returns>Asset with the given id.</returns>
     let getAsync (assetId: int64) : HttpContext -> Async<Context<AssetReadDto>> =
         getCore assetId fetch Async.single
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Runtime.InteropServices
-open System.Threading
-open System.Threading.Tasks
-
-open Oryx
-open CogniteSdk.Assets
 
 [<Extension>]
 type GetAssetClientExtensions =

--- a/src/assets/GetAssets.fs
+++ b/src/assets/GetAssets.fs
@@ -1,10 +1,15 @@
 namespace CogniteSdk.Assets
 
+open System
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
 
 open Oryx
 open Thoth.Json.Net
+
 open CogniteSdk
 
 // Get parameters
@@ -148,16 +153,6 @@ module Assets =
     /// <returns>List of assets and optional cursor.</returns>
     let listAsync (options: AssetQuery seq) : HttpContext -> Async<Context<AssetListResponse>> =
         listCore options fetch Async.single
-
-namespace CogniteSdk
-
-open System
-open System.Runtime.CompilerServices
-open System.Runtime.InteropServices
-open System.Threading
-
-open Oryx
-open CogniteSdk.Assets
 
 [<Extension>]
 type ListAssetsClientExtension =

--- a/src/assets/GetAssetsByIds.fs
+++ b/src/assets/GetAssetsByIds.fs
@@ -2,6 +2,10 @@ namespace CogniteSdk.Assets
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
@@ -60,17 +64,6 @@ module Retrieve =
     let getByIdsAsync (ids: Identity seq) =
         getByIdsCore ids fetch Async.single
 
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-
-open Oryx
-open CogniteSdk.Assets
 
 [<Extension>]
 type GetAssetsByIdsClientExtensions =

--- a/src/assets/Model.fs
+++ b/src/assets/Model.fs
@@ -14,7 +14,6 @@ type AssetEntity internal (externalId: string, name: string, description: string
     member val Description : string = description with get, set
     member val MetaData : IDictionary<string, string> = metaData with get, set
     member val Source : string = source with get, set
-
     member val Id : int64 = id with get
     member val CreatedTime : int64 = createdTime with get
     member val LastUpdatedTime : int64 = lastUpdatedTime with get
@@ -25,10 +24,10 @@ type AssetEntity internal (externalId: string, name: string, description: string
 
     /// Create new empty AssetEntity. Set content using the properties.
     new () =
-        AssetEntity(null, null, null, 0L, null, null, 0L, 0L, 0L, 0L, null)
+        AssetEntity(externalId=null, name=null, description=null, parentId=0L, metaData=null, source=null, id=0L, createdTime=0L, lastUpdatedTime=0L, rootId=0L, parentExternalId=null)
     /// Create new Asset.
     new (externalId: string, name: string, description: string, parentId: int64, metaData: IDictionary<string, string>, source: string, parentExternalId: string) =
-        AssetEntity(externalId, name, description, parentId, metaData, source, 0L, 0L, 0L, 0L, parentExternalId)
+        AssetEntity(externalId=externalId, name=name, description=description, parentId=parentId, metaData=metaData, source=source, id=0L, createdTime=0L, lastUpdatedTime=0L, rootId=0L, parentExternalId=parentExternalId)
 
 /// Read/write asset type.
 /// Asset type for responses.

--- a/src/assets/SearchAssets.fs
+++ b/src/assets/SearchAssets.fs
@@ -2,8 +2,13 @@
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
+open CogniteSdk.Assets
 open Thoth.Json.Net
 
 open CogniteSdk
@@ -92,17 +97,6 @@ module Search =
     /// <returns>List of assets matching given criteria.</returns>
     let searchAsync (limit: int) (options: AssetSearch seq) (filters: AssetFilter seq): HttpContext -> Async<Context<AssetReadDto seq>> =
         searchCore limit options filters fetch Async.single
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Oryx
-open CogniteSdk.Assets
-
 
 [<Extension>]
 type SearchAssetsClientExtensions =

--- a/src/assets/UpdateAssets.fs
+++ b/src/assets/UpdateAssets.fs
@@ -1,14 +1,19 @@
 namespace CogniteSdk.Assets
 
+open System
 open System.IO
 open System.Collections.Generic
 open System.Net.Http
-
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
 
 open CogniteSdk
+
 
 type MetaDataChange = {
     Add : Map<string, string> option
@@ -181,18 +186,6 @@ module Update =
     /// <returns>List of updated assets.</returns>
     let updateAsync (assets: (Identity * AssetUpdate list) list) : HttpContext -> Async<Context<AssetReadDto seq>> =
         updateCore assets fetch Async.single
-
-namespace CogniteSdk
-
-open System
-open System.Runtime.CompilerServices
-open System.Runtime.InteropServices
-open System.Threading
-open System.Threading.Tasks
-
-open Oryx
-open CogniteSdk.Assets
-
 
 [<Extension>]
 type UpdateAssetsClientExtensions =

--- a/src/timeseries/CreateTimeseries.fs
+++ b/src/timeseries/CreateTimeseries.fs
@@ -2,11 +2,16 @@ namespace CogniteSdk.TimeSeries
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
 
 open CogniteSdk
+
 
 [<RequireQualifiedAccess>]
 module Create =
@@ -57,16 +62,6 @@ module Create =
     let createAsync (items: seq<TimeSeriesWriteDto>) =
         createCore items fetch Async.single
 
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Oryx
-open CogniteSdk.TimeSeries
 
 [<Extension>]
 type CreateTimeSeriesClientExtensions =

--- a/src/timeseries/DeleteDataPoints.fs
+++ b/src/timeseries/DeleteDataPoints.fs
@@ -2,10 +2,15 @@ namespace CogniteSdk.DataPoints
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
 open CogniteSdk
+
 
 [<CLIMutable>]
 type DataPointsDelete = {
@@ -73,18 +78,6 @@ module Delete =
     /// <param name = "items">List of delete requests.</param>
     let deleteAsync (items: DeleteRequestDto seq) =
         deleteCore items fetch Async.single
-
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Oryx
-open CogniteSdk.DataPoints
-
 
 [<Extension>]
 type DeleteDataPointsClientExtensions =

--- a/src/timeseries/DeleteTimeseries.fs
+++ b/src/timeseries/DeleteTimeseries.fs
@@ -2,6 +2,10 @@ namespace CogniteSdk.TimeSeries
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
@@ -46,16 +50,6 @@ module Delete =
     /// <param name="items">List of timeseries ids to delete.</param>
     let deleteAsync (items: Identity seq) =
         deleteCore items fetch Async.single
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Oryx
-open CogniteSdk.TimeSeries
 
 [<Extension>]
 type DeleteTimeSeriesClientExtensions =

--- a/src/timeseries/GetAggregatedDataPoints.fs
+++ b/src/timeseries/GetAggregatedDataPoints.fs
@@ -2,8 +2,13 @@ namespace CogniteSdk.DataPoints
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Com.Cognite.V1.Timeseries.Proto
+
 open Oryx
 open Thoth.Json.Net
 
@@ -284,19 +289,6 @@ module Aggregated =
     /// <returns>List of aggregated data points in c# protobuf format.</returns>
     let getAggregatedMultipleProto (options: AggregateMultipleQuery seq) (defaultOptions: AggregateQuery seq) =
         getAggregatedProto options defaultOptions fetch Async.single
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Com.Cognite.V1.Timeseries.Proto
-
-open Oryx
-open CogniteSdk.DataPoints
-
 
 [<Extension>]
 type AggregatedClientExtensions =

--- a/src/timeseries/GetDataPoints.fs
+++ b/src/timeseries/GetDataPoints.fs
@@ -2,9 +2,12 @@ namespace CogniteSdk.DataPoints
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Com.Cognite.V1.Timeseries.Proto
-
 open Oryx
 open Thoth.Json.Net
 
@@ -182,19 +185,6 @@ module DataPoints =
     /// <returns>List of datapoint responses containing lists of datapoints for each timeseries as c# protobuf object.</returns>
     let listMultipleProtoAsync (options: DataPointMultipleQuery seq) (defaultOptions: DataPointQuery seq) =
         listProto options defaultOptions fetch Async.single
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Com.Cognite.V1.Timeseries.Proto
-
-open Oryx
-open CogniteSdk.DataPoints
-
 
 [<Extension>]
 type GetDataPointsClientExtensions =

--- a/src/timeseries/GetLatestDataPoint.fs
+++ b/src/timeseries/GetLatestDataPoint.fs
@@ -1,12 +1,16 @@
 ﻿namespace CogniteSdk.DataPoints
 
+open System
 open System.IO
 open System.Net.Http
-
-
-open Thoth.Json.Net
+open System.Runtime.InteropServices
+open System.Runtime.CompilerServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
+open Thoth.Json.Net
+
 open CogniteSdk
 open CogniteSdk.TimeSeries
 
@@ -117,18 +121,6 @@ module Latest =
     let getAsync (queryParams: LatestRequest seq) =
         getCore queryParams fetch Async.single
 
-
-namespace CogniteSdk
-
-open System
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Oryx
-open CogniteSdk.DataPoints
-open CogniteSdk.Common
 
 [<Extension>]
 type GetLatestDataPointExtensions =

--- a/src/timeseries/GetTimeseries.fs
+++ b/src/timeseries/GetTimeseries.fs
@@ -3,10 +3,16 @@ namespace CogniteSdk.TimeSeries
 open System
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
+
 open CogniteSdk
+
 
 // Get parameters
 type TimeSeriesQuery =
@@ -91,22 +97,6 @@ module TimeSeries =
     let listAsync (options: TimeSeriesQuery seq) =
         listCore options fetch Async.single
 
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Oryx
-open CogniteSdk.TimeSeries
-
-[<CLIMutable>]
-type TimeSeriesItems = {
-    Items: TimeSeriesEntity seq
-    NextCursor: string
-}
-
 [<Extension>]
 type ListTimeseriesClientExtensions =
     /// <summary>
@@ -116,7 +106,7 @@ type ListTimeseriesClientExtensions =
     /// <param name="options">Timeseries lookup options.</param>
     /// <returns>The timeseries with the given id and an optional cursor.</returns>
     [<Extension>]
-    static member ListAsync (this: TimeSeriesClientExtension, options: TimeSeries.TimeSeriesQuery seq, [<Optional>] token: CancellationToken) : Task<_> =
+    static member ListAsync (this: TimeSeriesClientExtension, options: TimeSeriesQuery seq, [<Optional>] token: CancellationToken) : Task<_> =
         async {
             let! ctx = TimeSeries.listAsync options this.Ctx
 

--- a/src/timeseries/GetTimeseriesByIds.fs
+++ b/src/timeseries/GetTimeseriesByIds.fs
@@ -2,10 +2,16 @@ namespace CogniteSdk.TimeSeries
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Threading.Tasks
+open System.Runtime.InteropServices
+open System.Threading
 
 open Oryx
 open Thoth.Json.Net
+
 open CogniteSdk
+open CogniteSdk.TimeSeries
 
 
 [<RequireQualifiedAccess>]
@@ -64,18 +70,6 @@ module GetByIds =
     /// <returns>The timeseries with the given ids.</returns>
     let getByIdsAsync (ids: seq<Identity>) =
         getByIdsCore ids fetch Async.single
-
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Oryx
-open CogniteSdk.TimeSeries
-
 
 [<Extension>]
 type GetTimeseriesByIdsClientExtensions =

--- a/src/timeseries/InsertDataPoints.fs
+++ b/src/timeseries/InsertDataPoints.fs
@@ -2,11 +2,14 @@ namespace CogniteSdk.DataPoints
 
 open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading.Tasks
+open System.Threading
 
 open Com.Cognite.V1.Timeseries.Proto
-
-
 open Oryx
+
 open CogniteSdk
 open CogniteSdk.TimeSeries
 
@@ -82,20 +85,6 @@ module Insert =
     /// <param name="items">The list of datapoint insertion requests as c# protobuf objects.</param>
     let insertAsyncProto (items: DataPointInsertionRequest) =
          insertCore items fetch Async.single
-
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-open Com.Cognite.V1.Timeseries.Proto
-open Oryx
-open CogniteSdk.DataPoints
-
-
 
 [<Extension>]
 type InsertDataPointsClientExtensions =

--- a/src/timeseries/Model.fs
+++ b/src/timeseries/Model.fs
@@ -34,6 +34,12 @@ type TimeSeriesEntity internal (externalId: string, name: string, description: s
     new (externalId: string, name: string, description: string, unit: string, isStep: bool, isString: bool, metaData: IDictionary<string, string>, securityCategories: int64 seq, assetId: int64, legacyName: string) =
         TimeSeriesEntity(externalId=externalId, name=name, description=description, unit=unit, isStep=isStep, isString=isString, metaData=metaData, securityCategories=securityCategories, id=0L, assetId=assetId, legacyName=legacyName, createdTime=0L, lastUpdatedTime=0L)
 
+[<CLIMutable>]
+type TimeSeriesItems = {
+    Items: TimeSeriesEntity seq
+    NextCursor: string
+}
+
 type NumericDataPointDto = {
     TimeStamp: int64
     Value: float
@@ -84,7 +90,6 @@ type AggregateDataPointReadDto = {
             DiscreteVariance = Some pt.DiscreteVariance
             TotalVariation = Some pt.TotalVariation
         }
-
 
 type TimeSeriesWriteDto = {
     /// Externally provided ID for the time series (optional, but recommended.)

--- a/src/timeseries/SearchTimeseries.fs
+++ b/src/timeseries/SearchTimeseries.fs
@@ -1,12 +1,19 @@
 namespace CogniteSdk.TimeSeries
 
-open System.IO
 open System.Collections.Generic
+open System.IO
 open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
 open CogniteSdk
+open CogniteSdk.TimeSeries
+
+
 
 type TimeSeriesSearch =
     private
@@ -137,19 +144,6 @@ module Search =
     /// <returns>Timeseries matching query.</returns>
     let searchAsync (limit: int) (options: TimeSeriesSearch seq) (filters: TimeSeriesFilter seq): HttpContext -> Async<Context<TimeSeriesReadDto seq>> =
         searchCore limit options filters fetch Async.single
-
-namespace CogniteSdk
-
-open System.Runtime.CompilerServices
-open System.Threading.Tasks
-open System.Runtime.InteropServices
-open System.Threading
-
-
-open Oryx
-open CogniteSdk
-open CogniteSdk.TimeSeries
-
 
 [<Extension>]
 type SearchTimeSeriesClientExtensions =

--- a/src/timeseries/UpdateTimeseries.fs
+++ b/src/timeseries/UpdateTimeseries.fs
@@ -2,13 +2,19 @@ namespace CogniteSdk.TimeSeries
 
 open System
 open System.Collections.Generic
-open System.Net.Http
 open System.IO
-
+open System.Net.Http
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+open System.Threading
+open System.Threading.Tasks
 
 open Oryx
 open Thoth.Json.Net
+
 open CogniteSdk
+open CogniteSdk.TimeSeries
+
 
 type MetaDataChange = {
     Add : Map<string, string> option
@@ -228,19 +234,6 @@ module Update =
     /// <returns>List of updated timeseries.</returns>
     let updateAsync (timeseries: (Identity * (TimeSeriesUpdate list)) list) : HttpContext -> Async<Context<TimeSeriesReadDto seq>> =
         updateCore timeseries fetch Async.single
-
-namespace CogniteSdk
-
-open System
-open System.Threading.Tasks
-open System.Runtime.CompilerServices
-open System.Runtime.InteropServices
-open System.Threading
-
-open Oryx
-open CogniteSdk
-open CogniteSdk.TimeSeries
-
 
 [<Extension>]
 type UpdateTimeseriesClientExtensions =


### PR DESCRIPTION
- Move extension methods back to subnamespace i.e CogniteSdk.Assets.
- Add named parameters to AssetEntity constructors to make them more robust.