### PR TITLE
Fix clear metadata

### DIFF
--- a/src/events/UpdateEvents.fs
+++ b/src/events/UpdateEvents.fs
@@ -124,17 +124,15 @@ module Update =
                 | None -> yield "setNull", Encode.bool true
             ]
         | CaseMetaData optMeta ->
-            match optMeta with
-            | Some (Set data) ->
-                "metadata", Encode.object [
+            "metadata", Encode.object [
+                match optMeta with
+                | Some (Set data) ->
                     yield "set", Encode.propertyBag data
-                ]
-            | Some (Change data) ->
-                "metadata", Encode.object [
+                | Some (Change data) ->
                     if data.Add.IsSome then yield "add", Encode.propertyBag data.Add.Value
                     yield "remove", Encode.seq (Seq.map Encode.string data.Remove)
-                ]
-            | None -> "set", Encode.object []
+                | None -> yield "set", Encode.object []
+            ]
         | CaseEventIds optAssetIds ->
             match optAssetIds with
             | Some ids ->

--- a/src/timeseries/UpdateTimeseries.fs
+++ b/src/timeseries/UpdateTimeseries.fs
@@ -144,7 +144,7 @@ module Update =
                     | MetaDataUpdate.Change data ->
                         if data.Add.IsSome then yield "add", Encode.propertyBag data.Add.Value
                         yield "remove", Encode.seq (Seq.map Encode.string data.Remove)
-                | None -> ()
+                | None -> yield "set", Encode.object []
             ]
         | CaseUnit unt ->
             "unit", Encode.object [


### PR DESCRIPTION
This fixes clearMetadata for timeseries. Events will work after it is fixed in the api.