### PR TITLE
[DT-1442] Add method for setting bearer token for client.

### DIFF
--- a/CogniteSdk.Types/Events/Event.cs
+++ b/CogniteSdk.Types/Events/Event.cs
@@ -86,8 +86,7 @@ namespace CogniteSdk
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
         public override bool Equals(object obj)
         {
-            return obj is Event dto &&
-                   Id == dto.Id;
+            return obj is Event dto && Id == dto.Id;
         }
 
         /// <summary>Serves as the default hash function.</summary>

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -130,6 +130,17 @@ namespace CogniteSdk
             }
 
             /// <summary>
+            /// Set authorization bearer token.
+            /// </summary>
+            /// <param name="token">Bearer token to set.</param>
+            /// <returns>Updated builder.</returns>
+            public Builder SetBearerToken(string token)
+            {
+                _context = Context.withBearerToken(token, _context);
+                return this;
+            }
+
+            /// <summary>
             /// Set project for accessing the API.
             /// </summary>
             /// <param name="project">Name of project.</param>

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -151,16 +151,16 @@ namespace CogniteSdk
             /// <summary>
             /// Set authentication handler.
             /// </summary>
-            /// <param name="authHandler">Authorization handler for getting bearer token.</param>
+            /// <param name="tokenProvider">Token provider for getting bearer token to use for the request.</param>
             /// <returns>Updated builder.</returns>
-            public Builder SetAuthHandler(Func<CancellationToken, Task<string>> authHandler)
+            public Builder SetTokenProvider(Func<CancellationToken, Task<string>> tokenProvider)
             {
-                if (authHandler is null)
+                if (tokenProvider is null)
                 {
-                    throw new ArgumentNullException(nameof(authHandler));
+                    throw new ArgumentNullException(nameof(tokenProvider));
                 }
 
-                _authHandler = authHandler;
+                _authHandler = tokenProvider;
                 return this;
             }
 

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 using Oryx;
@@ -12,6 +13,7 @@ using CogniteSdk.Resources;
 
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 using static Oryx.Cognite.ContextModule;
+using System.Threading;
 
 namespace CogniteSdk
 {
@@ -73,21 +75,22 @@ namespace CogniteSdk
         /// <summary>
         /// Client for making requests to the API.
         /// </summary>
+        /// <param name="authHandler">The authentication handler.</param>
         /// <param name="ctx">Context to use for this session.</param>
-        private Client(HttpContext ctx)
+        private Client(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx)
         {
             // Setup resources.
-            Assets = new AssetsResource(ctx);
-            TimeSeries = new TimeSeriesResource(ctx);
-            DataPoints =new DataPointsResource(ctx);
-            Events = new EventsResource(ctx);
-            Sequences = new SequencesResource(ctx);
-            Raw = new RawResource(ctx);
-            Files = new FilesResource(ctx);
-            Login = new LoginResource(ctx);
+            Assets = new AssetsResource(authHandler, ctx);
+            TimeSeries = new TimeSeriesResource(authHandler, ctx);
+            DataPoints = new DataPointsResource(authHandler, ctx);
+            Events = new EventsResource(authHandler, ctx);
+            Sequences = new SequencesResource(authHandler, ctx);
+            Raw = new RawResource(authHandler, ctx);
+            Files = new FilesResource(authHandler, ctx);
+            Login = new LoginResource(authHandler, ctx);
 
             // Playground features (experimental)
-            Playground = new PlaygroundResource(ctx);
+            Playground = new PlaygroundResource(authHandler, ctx);
         }
 
         /// <summary>
@@ -96,7 +99,8 @@ namespace CogniteSdk
         [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Builder pattern.")]
         public sealed class Builder
         {
-            private HttpContext _context = ContextModule.create ();
+            private HttpContext _context = create();
+            private Func<CancellationToken, Task<string>> _authHandler;
 
             /// <summary>
             /// Create Client builder.
@@ -115,6 +119,16 @@ namespace CogniteSdk
             /// <returns>Updated builder.</returns>
             public Builder AddHeader(string name, string value)
             {
+                if (name is null)
+                {
+                    throw new ArgumentNullException(nameof(name));
+                }
+
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 _context = Context.withHeader(name, value, _context);
                 return this;
             }
@@ -126,17 +140,27 @@ namespace CogniteSdk
             /// <returns>Updated builder.</returns>
             public Builder SetApiKey(string apiKey)
             {
+                if (apiKey is null)
+                {
+                    throw new ArgumentNullException(nameof(apiKey));
+                }
+
                 return AddHeader("api-key", apiKey);
             }
 
             /// <summary>
-            /// Set authorization bearer token.
+            /// Set authentication handler.
             /// </summary>
-            /// <param name="token">Bearer token to set.</param>
+            /// <param name="authHandler">Authorization handler for getting bearer token.</param>
             /// <returns>Updated builder.</returns>
-            public Builder SetBearerToken(string token)
+            public Builder SetAuthHandler(Func<CancellationToken, Task<string>> authHandler)
             {
-                _context = Context.withBearerToken(token, _context);
+                if (authHandler is null)
+                {
+                    throw new ArgumentNullException(nameof(authHandler));
+                }
+
+                _authHandler = authHandler;
                 return this;
             }
 
@@ -147,6 +171,11 @@ namespace CogniteSdk
             /// <returns>Updated builder.</returns>
             public Builder SetProject(string project)
             {
+                if (project is null)
+                {
+                    throw new ArgumentNullException(nameof(project));
+                }
+
                 _context = withProject(project, _context);
                 return this;
             }
@@ -158,6 +187,11 @@ namespace CogniteSdk
             /// <returns>Updated builder.</returns>
             public Builder SetAppId(string appId)
             {
+                if (appId is null)
+                {
+                    throw new ArgumentNullException(nameof(appId));
+                }
+
                 _context = withAppId(appId, _context);
                 return this;
             }
@@ -169,6 +203,11 @@ namespace CogniteSdk
             /// <returns>Updated builder.</returns>
             public Builder SetHttpClient(HttpClient client)
             {
+                if (client is null)
+                {
+                    throw new ArgumentNullException(nameof(client));
+                }
+
                 _context = Context.withHttpClient(client, _context);
                 return this;
             }
@@ -223,6 +262,11 @@ namespace CogniteSdk
             /// <returns>Updated builder.</returns>
             public Builder SetLogFormat(string format)
             {
+                if (format is null)
+                {
+                    throw new ArgumentNullException(nameof(format));
+                }
+
                 _context = Context.withLogFormat(format, _context);
                 return this;
             }
@@ -238,6 +282,7 @@ namespace CogniteSdk
                 {
                     throw new ArgumentNullException(nameof(metrics));
                 }
+
                 _context = Context.withMetrics(metrics, _context);
                 return this;
             }
@@ -250,8 +295,12 @@ namespace CogniteSdk
             {
                 // Check for optional fields etc here
                 HttpContext ctx = _context;
-                _context = null; // Builder is invalid after this
-                return new Client(ctx);
+                Func<CancellationToken, Task<string>> authHandler = _authHandler;
+
+                // Builder is invalid after this
+                _context = null;
+                _authHandler = null;
+                return new Client(authHandler, ctx);
             }
 
             /// <summary>

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -1,12 +1,13 @@
 // Copyright 2019 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CogniteSdk;
+using Oryx.Cognite;
 using static Oryx.Cognite.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
@@ -15,17 +16,15 @@ namespace CogniteSdk.Resources
     /// <summary>
     /// For internal use. Contains all asset methods.
     /// </summary>
-    public class AssetsResource
+    public class AssetsResource : Resource
     {
-        private readonly HttpContext _ctx;
-
         /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
+        /// <param name="authHandler">Authentication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal AssetsResource(HttpContext ctx)
+        internal AssetsResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
         {
-            _ctx = ctx;
         }
 
         /// <summary>
@@ -36,8 +35,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given filters and optional cursor</returns>
         public async Task<ItemsWithCursor<Asset>> ListAsync(AssetQuery query, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.Assets.list<ItemsWithCursor<Asset>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            var req = Assets.list<ItemsWithCursor<Asset>>(query);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -48,8 +52,13 @@ namespace CogniteSdk.Resources
         /// <returns>Sequence of created assets.</returns>
         public async Task<IEnumerable<Asset>> CreateAsync(IEnumerable<AssetCreate> assets, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.Assets.create<IEnumerable<Asset>>(assets);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            if (assets is null)
+            {
+                throw new ArgumentNullException(nameof(assets));
+            }
+
+            var req = Assets.create<IEnumerable<Asset>>(assets);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -60,8 +69,8 @@ namespace CogniteSdk.Resources
         /// <returns>Asset with the given id.</returns>
         public async Task<Asset> GetAsync(long assetId, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.Assets.get<Asset>(assetId);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            var req = Assets.get<Asset>(assetId);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         #region Delete overloads
@@ -73,8 +82,13 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(AssetDelete query, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.Assets.delete<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            var req = Assets.delete<EmptyResponse>(query);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -84,6 +98,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<Identity> items, CancellationToken token = default)
         {
+            if (items is null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
             var query = new AssetDelete() { Items = items };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }
@@ -95,6 +114,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<long> internalIds, CancellationToken token = default)
         {
+            if (internalIds is null)
+            {
+                throw new ArgumentNullException(nameof(internalIds));
+            }
+
             var query = new AssetDelete() { Items = internalIds.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }
@@ -106,6 +130,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<string> externalIds, CancellationToken token = default)
         {
+            if (externalIds is null)
+            {
+                throw new ArgumentNullException(nameof(externalIds));
+            }
+
             var query = new AssetDelete() { Items = externalIds.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }
@@ -120,8 +149,13 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Asset>> RetrieveAsync(IEnumerable<Identity> ids, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.Assets.retrieve<IEnumerable<Asset>>(ids);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            if (ids is null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
+            var req = Assets.retrieve<IEnumerable<Asset>>(ids);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -132,6 +166,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Asset>> RetrieveAsync(IEnumerable<long> internalIds, CancellationToken token = default)
         {
+            if (internalIds is null)
+            {
+                throw new ArgumentNullException(nameof(internalIds));
+            }
+
             var ids = internalIds.Select(Identity.Create);
             return await RetrieveAsync(ids, token).ConfigureAwait(false);
         }
@@ -144,6 +183,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Asset>> RetrieveAsync(IEnumerable<string> externalIds, CancellationToken token = default)
         {
+            if (externalIds is null)
+            {
+                throw new ArgumentNullException(nameof(externalIds));
+            }
+
             var ids = externalIds.Select(Identity.Create);
             return await RetrieveAsync(ids, token).ConfigureAwait(false);
         }
@@ -157,8 +201,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given criteria.</returns>
         public async Task<IEnumerable<Asset>> SearchAsync (AssetSearch query, CancellationToken token = default )
         {
-            var req = Oryx.Cognite.Assets.search<IEnumerable<Asset>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            var req = Assets.search<IEnumerable<Asset>>(query);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -170,8 +219,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of updated assets.</returns>
         public async Task<IEnumerable<Asset>> UpdateAsync (IEnumerable<AssetUpdateItem> query, CancellationToken token = default )
         {
-            var req = Oryx.Cognite.Assets.update<IEnumerable<Asset>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            var req = Assets.update<IEnumerable<Asset>>(query);
+            return await Run(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -41,7 +41,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Assets.list<ItemsWithCursor<Asset>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Assets.create<IEnumerable<Asset>>(assets);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace CogniteSdk.Resources
         public async Task<Asset> GetAsync(long assetId, CancellationToken token = default)
         {
             var req = Assets.get<Asset>(assetId);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         #region Delete overloads
@@ -88,7 +88,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Assets.delete<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Assets.retrieve<IEnumerable<Asset>>(ids);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Assets.search<IEnumerable<Asset>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Assets.update<IEnumerable<Asset>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/DataPoints.cs
+++ b/CogniteSdk/src/Resources/DataPoints.cs
@@ -1,13 +1,13 @@
 // Copyright 2019 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Com.Cognite.V1.Timeseries.Proto;
 using static Oryx.Cognite.HandlerModule;
-using CogniteSdk;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources
@@ -15,17 +15,15 @@ namespace CogniteSdk.Resources
     /// <summary>
     /// For internal use. Contains all data points methods.
     /// </summary>
-    public class DataPointsResource
+    public class DataPointsResource : Resource
     {
-        private readonly HttpContext _ctx;
-
         /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
+        /// <param name="authHandler">Authentication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal DataPointsResource(HttpContext ctx)
+        internal DataPointsResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
         {
-            _ctx = ctx;
         }
 
         /// <summary>
@@ -36,8 +34,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given filters and optional cursor</returns>
         public async Task<DataPointListResponse> ListAsync(DataPointsQuery query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.DataPoints.list<DataPointListResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -48,8 +51,13 @@ namespace CogniteSdk.Resources
         /// <returns>Empty response.</returns>
         public async Task<EmptyResponse> CreateAsync(DataPointInsertionRequest points, CancellationToken token = default)
         {
+            if (points is null)
+            {
+                throw new ArgumentNullException(nameof(points));
+            }
+
             var req = Oryx.Cognite.DataPoints.create<EmptyResponse>(points);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -61,8 +69,13 @@ namespace CogniteSdk.Resources
         /// <returns>Empty response.</returns>
         public async Task<EmptyResponse> DeleteAsync(DataPointsDelete query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.DataPoints.delete<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -73,8 +86,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of latest data points.</returns>
         public async Task<IEnumerable<DataPointsItem<DataPoint>>> LatestAsync(DataPointsLatestQuery query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.DataPoints.latest<IEnumerable<DataPointsItem<DataPoint>>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/DataPoints.cs
+++ b/CogniteSdk/src/Resources/DataPoints.cs
@@ -40,7 +40,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.DataPoints.list<DataPointListResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.DataPoints.create<EmptyResponse>(points);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.DataPoints.delete<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.DataPoints.latest<IEnumerable<DataPointsItem<DataPoint>>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -40,7 +40,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Events.list<ItemsWithCursor<Event>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Events.create<IEnumerable<Event>>(events);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace CogniteSdk.Resources
         public async Task<Event> GetAsync(long eventId, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Events.get<Event>(eventId);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
 
@@ -87,7 +87,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Events.delete<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Events.retrieve<IEnumerable<Event>>(ids);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Events.search<IEnumerable<Event>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Events.update<IEnumerable<Event>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -1,12 +1,12 @@
 // Copyright 2019 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CogniteSdk;
 using static Oryx.Cognite.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
@@ -15,17 +15,15 @@ namespace CogniteSdk.Resources
     /// <summary>
     /// For internal use. Contains all event methods.
     /// </summary>
-    public class EventsResource
+    public class EventsResource : Resource
     {
-        private readonly HttpContext _ctx;
-
         /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
+        /// <param name="authHandler">Authentication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal EventsResource(HttpContext ctx)
+        internal EventsResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
         {
-            _ctx = ctx;
         }
 
         /// <summary>
@@ -36,8 +34,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given filters and optional cursor</returns>
         public async Task<ItemsWithCursor<Event>> ListAsync(EventQuery query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Events.list<ItemsWithCursor<Event>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -48,8 +51,13 @@ namespace CogniteSdk.Resources
         /// <returns></returns>
         public async Task<IEnumerable<Event>> CreateAsync(IEnumerable<EventCreate> events, CancellationToken token = default)
         {
+            if (events is null)
+            {
+                throw new ArgumentNullException(nameof(events));
+            }
+
             var req = Oryx.Cognite.Events.create<IEnumerable<Event>>(events);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -61,7 +69,7 @@ namespace CogniteSdk.Resources
         public async Task<Event> GetAsync(long eventId, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Events.get<Event>(eventId);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
 
@@ -73,8 +81,13 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(EventDelete query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Events.delete<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -84,6 +97,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<Identity> identities, CancellationToken token = default)
         {
+            if (identities is null)
+            {
+                throw new ArgumentNullException(nameof(identities));
+            }
+
             var query = new EventDelete { Items = identities };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }
@@ -95,6 +113,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<long> ids, CancellationToken token = default)
         {
+            if (ids is null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
             var query = new EventDelete { Items = ids.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }
@@ -106,6 +129,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<string> externalIds, CancellationToken token = default)
         {
+            if (externalIds is null)
+            {
+                throw new ArgumentNullException(nameof(externalIds));
+            }
+
             var query = new EventDelete { Items = externalIds.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }
@@ -121,8 +149,13 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Event>> RetrieveAsync(IEnumerable<Identity> ids, CancellationToken token = default)
         {
+            if (ids is null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
             var req = Oryx.Cognite.Events.retrieve<IEnumerable<Event>>(ids);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -133,6 +166,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Event>> RetrieveAsync(IEnumerable<long> internalIds, CancellationToken token = default)
         {
+            if (internalIds is null)
+            {
+                throw new ArgumentNullException(nameof(internalIds));
+            }
+
             var req = internalIds.Select(Identity.Create);
             return await RetrieveAsync(req, token).ConfigureAwait(false);
         }
@@ -145,6 +183,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Event>> RetrieveAsync(IEnumerable<string> externalIds, CancellationToken token = default)
         {
+            if (externalIds is null)
+            {
+                throw new ArgumentNullException(nameof(externalIds));
+            }
+
             var req = externalIds.Select(Identity.Create);
             return await RetrieveAsync(req, token).ConfigureAwait(false);
         }
@@ -158,8 +201,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given criteria.</returns>
         public async Task<IEnumerable<Event>> SearchAsync (EventSearch query, CancellationToken token = default )
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Events.search<IEnumerable<Event>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -171,8 +219,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of updated assets.</returns>
         public async Task<IEnumerable<Event>> UpdateAsync (IEnumerable<EventUpdateItem> query, CancellationToken token = default )
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Events.update<IEnumerable<Event>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Files.cs
+++ b/CogniteSdk/src/Resources/Files.cs
@@ -35,7 +35,7 @@ namespace CogniteSdk.Resources
         public async Task<ItemsWithCursor<File>> ListAsync(FileQuery query, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Files.list<ItemsWithCursor<File>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace CogniteSdk.Resources
         public async Task<File> GetAsync(long fileId, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Files.get<File>(fileId);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         #region Retrieve overloads
@@ -60,7 +60,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<File>> RetrieveAsync(IEnumerable<Identity> ids, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Files.retrieve<IEnumerable<File>>(ids);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<FileDownload>> DownloadAsync(IEnumerable<Identity> ids, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Files.download<IEnumerable<FileDownload>>(ids);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Files.upload<FileUploadRead>(file, overwrite);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Files.update<IEnumerable<File>>(update);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         #region Delete overloads
@@ -196,7 +196,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Files.delete<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/CogniteSdk/src/Resources/Files.cs
+++ b/CogniteSdk/src/Resources/Files.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright 2019 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CogniteSdk.Files;
 using static Oryx.Cognite.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
@@ -15,17 +15,15 @@ namespace CogniteSdk.Resources
     /// <summary>
     /// For internal use. Contains all event methods.
     /// </summary>
-    public class FilesResource
+    public class FilesResource : Resource
     {
-        private readonly HttpContext _ctx;
-
         /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
+        /// <param name="authHandler">The authetication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal FilesResource(HttpContext ctx)
+        internal FilesResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
         {
-            _ctx = ctx;
         }
 
         /// <summary>
@@ -37,7 +35,7 @@ namespace CogniteSdk.Resources
         public async Task<ItemsWithCursor<File>> ListAsync(FileQuery query, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Files.list<ItemsWithCursor<File>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -49,7 +47,7 @@ namespace CogniteSdk.Resources
         public async Task<File> GetAsync(long fileId, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Files.get<File>(fileId);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         #region Retrieve overloads
@@ -62,7 +60,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<File>> RetrieveAsync(IEnumerable<Identity> ids, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Files.retrieve<IEnumerable<File>>(ids);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -102,7 +100,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<FileDownload>> DownloadAsync(IEnumerable<Identity> ids, CancellationToken token = default)
         {
             var req = Oryx.Cognite.Files.download<IEnumerable<FileDownload>>(ids);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -157,8 +155,13 @@ namespace CogniteSdk.Resources
         /// <returns>The Updated file.</returns>
         public async Task<FileUploadRead> UploadAsync(FileCreate file, bool overwrite=false, CancellationToken token = default)
         {
+            if (file is null)
+            {
+                throw new ArgumentNullException(nameof(file));
+            }
+
             var req = Oryx.Cognite.Files.upload<FileUploadRead>(file, overwrite);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -169,8 +172,13 @@ namespace CogniteSdk.Resources
         /// <returns>The updated files.</returns>
         public async Task<IEnumerable<File>> UpdateAsync(IEnumerable<FileUpdateItem> update, CancellationToken token = default)
         {
+            if (update is null)
+            {
+                throw new ArgumentNullException(nameof(update));
+            }
+
             var req = Oryx.Cognite.Files.update<IEnumerable<File>>(update);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         #region Delete overloads
@@ -182,8 +190,13 @@ namespace CogniteSdk.Resources
         /// <returns>Empty response.</returns>
         public async Task<EmptyResponse> DeleteAsync(FileDelete query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Files.delete<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -193,6 +206,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<Identity> identities, CancellationToken token = default)
         {
+            if (identities is null)
+            {
+                throw new ArgumentNullException(nameof(identities));
+            }
+
             var query = new FileDelete { Items = identities };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }
@@ -204,6 +222,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<long> ids, CancellationToken token = default)
         {
+            if (ids is null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
             var query = new FileDelete { Items = ids.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }
@@ -215,6 +238,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<string> externalIds, CancellationToken token = default)
         {
+            if (externalIds is null)
+            {
+                throw new ArgumentNullException(nameof(externalIds));
+            }
+
             var query = new FileDelete { Items = externalIds.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }

--- a/CogniteSdk/src/Resources/Login.cs
+++ b/CogniteSdk/src/Resources/Login.cs
@@ -1,6 +1,7 @@
 // Copyright 2019 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,17 +14,15 @@ namespace CogniteSdk.Resources
     /// <summary>
     /// For internal use. Contains all event methods.
     /// </summary>
-    public class LoginResource
+    public class LoginResource : Resource
     {
-        private readonly HttpContext _ctx;
-
         /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
+        /// <param name="authHandler">The authentication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal LoginResource(HttpContext ctx)
+        internal LoginResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
         {
-            _ctx = ctx;
         }
 
         /// <summary>
@@ -34,7 +33,7 @@ namespace CogniteSdk.Resources
         public async Task<LoginStatus> StatusAsync(CancellationToken token = default)
         {
             var req = Oryx.Cognite.Login.status<LoginStatus>();
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Login.cs
+++ b/CogniteSdk/src/Resources/Login.cs
@@ -33,7 +33,7 @@ namespace CogniteSdk.Resources
         public async Task<LoginStatus> StatusAsync(CancellationToken token = default)
         {
             var req = Oryx.Cognite.Login.status<LoginStatus>();
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Playground.cs
+++ b/CogniteSdk/src/Resources/Playground.cs
@@ -1,6 +1,9 @@
 // Copyright 2020 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources
@@ -8,10 +11,8 @@ namespace CogniteSdk.Resources
     /// <summary>
     /// For internal use. Contains all Playground resources.
     /// </summary>
-    public class PlaygroundResource
+    public class PlaygroundResource : Resource
     {
-        private readonly HttpContext _ctx;
-
         /// <summary>
         /// Client Relationships extension methods
         /// </summary>
@@ -20,11 +21,11 @@ namespace CogniteSdk.Resources
         /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
+        /// <param name="authHandler">The authntication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal PlaygroundResource(HttpContext ctx)
+        internal PlaygroundResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
         {
-            _ctx = ctx;
-            Relationships = new RelationshipResource(ctx);
+            Relationships = new RelationshipResource(authHandler, ctx);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Raw.cs
+++ b/CogniteSdk/src/Resources/Raw.cs
@@ -40,7 +40,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Raw.listDatabases<ItemsWithCursor<RawDatabase>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace CogniteSdk.Resources
         {
             var query = new RawDatabaseQuery();
             var req = Oryx.Cognite.Raw.listDatabases<ItemsWithCursor<RawDatabase>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Raw.createDatabases<IEnumerable<RawDatabase>>(items);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Raw.deleteDatabases<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Raw.listTables<ItemsWithCursor<RawTable>>(database, query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Raw.createTables<IEnumerable<RawTable>>(database, items, ensureParent);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Raw.deleteTables<EmptyResponse>(database, query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -289,7 +289,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Raw.listRows<ItemsWithCursor<RawRow>>(database, table, query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Raw.createRows<EmptyResponse>(database, table, dtos, ensureParent);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -371,7 +371,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Raw.deleteRows<EmptyResponse>(database, table, dtos);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Relationships.cs
+++ b/CogniteSdk/src/Resources/Relationships.cs
@@ -1,6 +1,7 @@
 // Copyright 2020 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,17 +15,15 @@ namespace CogniteSdk.Resources
     /// <summary>
     /// For internal use. Contains all relationship methods.
     /// </summary>
-    public class RelationshipResource
+    public class RelationshipResource : Resource
     {
-        private readonly HttpContext _ctx;
-
         /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
+        /// <param name="authHandler">The authentication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal RelationshipResource(HttpContext ctx)
+        internal RelationshipResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
         {
-            _ctx = ctx;
         }
 
         /// <summary>
@@ -35,8 +34,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of Relationships matching given filters and optional cursor</returns>
         public async Task<ItemsWithCursor<Relationship>> ListAsync(RelationshipQuery query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Relationships.list<ItemsWithCursor<Relationship>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -47,8 +51,13 @@ namespace CogniteSdk.Resources
         /// <returns>Sequence of created Relationships.</returns>
         public async Task<ItemsWithoutCursor<Relationship>> CreateAsync(IEnumerable<RelationshipCreate> relationships, CancellationToken token = default)
         {
+            if (relationships is null)
+            {
+                throw new ArgumentNullException(nameof(relationships));
+            }
+
             var req = Oryx.Cognite.Relationships.create<ItemsWithoutCursor<Relationship>>(relationships);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -59,8 +68,13 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<string> externalIds, CancellationToken token = default)
         {
+            if (externalIds is null)
+            {
+                throw new ArgumentNullException(nameof(externalIds));
+            }
+
             var req = Oryx.Cognite.Relationships.delete<EmptyResponse>(externalIds);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -71,8 +85,13 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<ItemsWithoutCursor<Relationship>> RetrieveAsync(IEnumerable<string> ids, CancellationToken token = default)
         {
+            if (ids is null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
             var req = Oryx.Cognite.Relationships.retrieve<ItemsWithoutCursor<Relationship>>(ids);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -83,8 +102,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of relationships matching given criteria.</returns>
         public async Task<RestrictedGraphQueryResult> SearchAsync (RestrictedGraphQuery query, CancellationToken token = default )
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Relationships.search<RestrictedGraphQueryResult>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Relationships.cs
+++ b/CogniteSdk/src/Resources/Relationships.cs
@@ -40,7 +40,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Relationships.list<ItemsWithCursor<Relationship>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Relationships.create<ItemsWithoutCursor<Relationship>>(relationships);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Relationships.delete<EmptyResponse>(externalIds);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Relationships.retrieve<ItemsWithoutCursor<Relationship>>(ids);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Relationships.search<RestrictedGraphQueryResult>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Resource.cs
+++ b/CogniteSdk/src/Resources/Resource.cs
@@ -46,7 +46,7 @@ namespace CogniteSdk.Resources
         /// <param name="token">The cancellation token to use.</param>
         /// <typeparam name="T">The type of the response.</typeparam>
         /// <returns>Result.</returns>
-        protected async Task<T> Run<T>(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.FSharpFunc<Oryx.Context<T>, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>, Microsoft.FSharp.Core.FSharpFunc<HttpContext, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>> handler, CancellationToken token)
+        protected async Task<T> RunAsync<T>(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.FSharpFunc<Oryx.Context<T>, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>, Microsoft.FSharp.Core.FSharpFunc<HttpContext, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>> handler, CancellationToken token)
         {
 
             var req = _authHandler is null ? handler : withTokenProvider(_authHandler, handler);

--- a/CogniteSdk/src/Resources/Resource.cs
+++ b/CogniteSdk/src/Resources/Resource.cs
@@ -49,7 +49,7 @@ namespace CogniteSdk.Resources
         protected async Task<T> Run<T>(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.FSharpFunc<Oryx.Context<T>, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>, Microsoft.FSharp.Core.FSharpFunc<HttpContext, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>> handler, CancellationToken token)
         {
 
-            var req = _authHandler is null ? handler : withAuth(_authHandler, handler);
+            var req = _authHandler is null ? handler : withTokenProvider(_authHandler, handler);
             return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
         }
     }

--- a/CogniteSdk/src/Resources/Resource.cs
+++ b/CogniteSdk/src/Resources/Resource.cs
@@ -1,0 +1,56 @@
+// Copyright 2019 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+using Oryx.Cognite;
+using static Oryx.Cognite.HandlerModule;
+using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
+
+namespace CogniteSdk.Resources
+{
+    /// <summary>
+    /// For internal use. Contains all asset methods.
+    /// </summary>
+    public abstract class Resource
+    {
+        /// <summary>
+        /// The context.
+        /// </summary>
+        protected readonly HttpContext _ctx;
+        /// <summary>
+        /// The authentication handler.
+        /// </summary>
+        protected readonly Func<CancellationToken, Task<string>> _authHandler;
+
+        /// <summary>
+        /// Will only be instantiated by the client.
+        /// </summary>
+        /// <param name="authHandler">Authentication handler.</param>
+        /// <param name="ctx">Context to use for the request.</param>
+        internal Resource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx)
+        {
+            _ctx = ctx;
+            _authHandler = authHandler;
+        }
+
+        /// <summary>
+        /// Helper method for running an Oryx handler in the client context with authentication handling.
+        /// </summary>
+        /// <param name="handler">The handler to run.</param>
+        /// <param name="token">The cancellation token to use.</param>
+        /// <typeparam name="T">The type of the response.</typeparam>
+        /// <returns>Result.</returns>
+        protected async Task<T> Run<T>(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.FSharpFunc<Oryx.Context<T>, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>, Microsoft.FSharp.Core.FSharpFunc<HttpContext, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>> handler, CancellationToken token)
+        {
+
+            var req = _authHandler is null ? handler : withAuth(_authHandler, handler);
+            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+        }
+    }
+}

--- a/CogniteSdk/src/Resources/Sequences.cs
+++ b/CogniteSdk/src/Resources/Sequences.cs
@@ -40,7 +40,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Sequences.list<ItemsWithCursor<Sequence>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Sequences.create<IEnumerable<SequenceData>>(sequences);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         #region Delete overloads
@@ -74,7 +74,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Sequences.delete<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Sequences.retrieve<IEnumerable<Sequence>>(ids);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Sequences.search<IEnumerable<Sequence>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Sequences.update<IEnumerable<Sequence>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Sequences.listRows<SequenceData>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Sequences.createRows<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.Sequences.deleteRows<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Sequences.cs
+++ b/CogniteSdk/src/Resources/Sequences.cs
@@ -1,12 +1,12 @@
 // Copyright 2019 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CogniteSdk;
 using static Oryx.Cognite.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
@@ -15,17 +15,15 @@ namespace CogniteSdk.Resources
     /// <summary>
     /// For internal use. Contains all sequences methods.
     /// </summary>
-    public class SequencesResource
+    public class SequencesResource : Resource
     {
-        private readonly HttpContext _ctx;
-
         /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
+        /// <param name="authHandler">The authentication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal SequencesResource(HttpContext ctx)
+        internal SequencesResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
         {
-            _ctx = ctx;
         }
 
         /// <summary>
@@ -36,8 +34,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given filters and optional cursor</returns>
         public async Task<ItemsWithCursor<Sequence>> ListAsync(SequenceQuery query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Sequences.list<ItemsWithCursor<Sequence>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -48,8 +51,13 @@ namespace CogniteSdk.Resources
         /// <returns></returns>
         public async Task<IEnumerable<SequenceData>> CreateAsync(IEnumerable<SequenceCreate> sequences, CancellationToken token = default)
         {
+            if (sequences is null)
+            {
+                throw new ArgumentNullException(nameof(sequences));
+            }
+
             var req = Oryx.Cognite.Sequences.create<IEnumerable<SequenceData>>(sequences);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         #region Delete overloads
@@ -60,8 +68,13 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<Identity> query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Sequences.delete<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -71,6 +84,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<long> internalIds, CancellationToken token = default)
         {
+            if (internalIds is null)
+            {
+                throw new ArgumentNullException(nameof(internalIds));
+            }
+
             var req = internalIds.Select(Identity.Create);
             return await DeleteAsync(req, token).ConfigureAwait(false);
         }
@@ -82,6 +100,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<string> internalIds, CancellationToken token = default)
         {
+            if (internalIds is null)
+            {
+                throw new ArgumentNullException(nameof(internalIds));
+            }
+
             var req = internalIds.Select(Identity.Create);
             return await DeleteAsync(req, token).ConfigureAwait(false);
         }
@@ -96,8 +119,13 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Sequence>> RetrieveAsync(IEnumerable<Identity> ids, CancellationToken token = default)
         {
+            if (ids is null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
             var req = Oryx.Cognite.Sequences.retrieve<IEnumerable<Sequence>>(ids);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -108,6 +136,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Sequence>> RetrieveAsync(IEnumerable<long> internalIds, CancellationToken token = default)
         {
+            if (internalIds is null)
+            {
+                throw new ArgumentNullException(nameof(internalIds));
+            }
+
             var req = internalIds.Select(Identity.Create);
             return await RetrieveAsync(req, token).ConfigureAwait(false);
         }
@@ -120,6 +153,11 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Sequence>> RetrieveAsync(IEnumerable<string> externalIds, CancellationToken token = default)
         {
+            if (externalIds is null)
+            {
+                throw new ArgumentNullException(nameof(externalIds));
+            }
+
             var req = externalIds.Select(Identity.Create);
             return await RetrieveAsync(req, token).ConfigureAwait(false);
         }
@@ -133,8 +171,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given criteria.</returns>
         public async Task<IEnumerable<Sequence>> SearchAsync (SequenceSearch query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Sequences.search<IEnumerable<Sequence>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -145,8 +188,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of updated assets.</returns>
         public async Task<IEnumerable<Sequence>> UpdateAsync (IEnumerable<UpdateItem<SequenceUpdate>> query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Sequences.update<IEnumerable<Sequence>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -159,8 +207,13 @@ namespace CogniteSdk.Resources
         /// <returns>Sequence read data.</returns>
         public async Task<SequenceData> ListRowsAsync(SequenceRowQuery query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Sequences.listRows<SequenceData>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -171,8 +224,13 @@ namespace CogniteSdk.Resources
         /// <returns>Empty response.</returns>
         public async Task<EmptyResponse> CreateRowsAsync(IEnumerable<SequenceDataCreate> query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Sequences.createRows<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -183,8 +241,13 @@ namespace CogniteSdk.Resources
         /// <returns>Empty response.</returns>
         public async Task<EmptyResponse> DeleteRowsAsync(IEnumerable<SequenceRowDelete> query, CancellationToken token = default)
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.Sequences.deleteRows<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -10,23 +10,22 @@ using static Oryx.Cognite.HandlerModule;
 using CogniteSdk;
 
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
+using System;
 
 namespace CogniteSdk.Resources
 {
     /// <summary>
     /// For internal use. Contains all data points methods.
     /// </summary>
-    public class TimeSeriesResource
+    public class TimeSeriesResource : Resource
     {
-        private readonly HttpContext _ctx;
-
         /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
+        /// <param name="authHandler">The authentication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal TimeSeriesResource(HttpContext ctx)
+        internal TimeSeriesResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
         {
-            _ctx = ctx;
         }
 
         /// <summary>
@@ -38,7 +37,7 @@ namespace CogniteSdk.Resources
         public async Task<ItemsWithCursor<TimeSeries>> ListAsync(TimeSeriesQuery query, CancellationToken token = default)
         {
             var req = Oryx.Cognite.TimeSeries.list<ItemsWithCursor<TimeSeries>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -50,7 +49,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<TimeSeries>> CreateAsync(IEnumerable<TimeSeriesCreate> timeseries, CancellationToken token = default)
         {
             var req = Oryx.Cognite.TimeSeries.create<IEnumerable<TimeSeries>>(timeseries);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -61,7 +60,7 @@ namespace CogniteSdk.Resources
         public async Task<EmptyResponse> DeleteAsync(TimeSeriesDelete query, CancellationToken token = default)
         {
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -73,7 +72,7 @@ namespace CogniteSdk.Resources
         {
             var query = new TimeSeriesDelete { Items=internalIds.Select(Identity.Create) };
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -85,7 +84,7 @@ namespace CogniteSdk.Resources
         {
             var query = new TimeSeriesDelete { Items=externalIds.Select(Identity.Create) };
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -97,7 +96,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<Identity> ids, CancellationToken token = default)
         {
             var req = Oryx.Cognite.TimeSeries.retrieve<IEnumerable<TimeSeries>>(ids);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -110,7 +109,7 @@ namespace CogniteSdk.Resources
         {
             var ids = internalIds.Select(Identity.Create);
             var req = Oryx.Cognite.TimeSeries.retrieve<IEnumerable<TimeSeries>>(ids);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -123,7 +122,7 @@ namespace CogniteSdk.Resources
         {
             var ids = externalIds.Select(Identity.Create);
             var req = Oryx.Cognite.TimeSeries.retrieve<IEnumerable<TimeSeries>>(ids);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -134,8 +133,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given criteria.</returns>
         public async Task<IEnumerable<TimeSeries>> SearchAsync (TimeSeriesSearch query, CancellationToken token = default )
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.TimeSeries.search<IEnumerable<TimeSeries>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -147,8 +151,13 @@ namespace CogniteSdk.Resources
         /// <returns>List of updated timeseries.</returns>
         public async Task<IEnumerable<TimeSeries>> UpdateAsync (IEnumerable<TimeSeriesUpdateItem> query, CancellationToken token = default )
         {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
             var req = Oryx.Cognite.TimeSeries.update<IEnumerable<TimeSeries>>(query);
-            return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
+            return await Run(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -37,7 +37,7 @@ namespace CogniteSdk.Resources
         public async Task<ItemsWithCursor<TimeSeries>> ListAsync(TimeSeriesQuery query, CancellationToken token = default)
         {
             var req = Oryx.Cognite.TimeSeries.list<ItemsWithCursor<TimeSeries>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<TimeSeries>> CreateAsync(IEnumerable<TimeSeriesCreate> timeseries, CancellationToken token = default)
         {
             var req = Oryx.Cognite.TimeSeries.create<IEnumerable<TimeSeries>>(timeseries);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace CogniteSdk.Resources
         public async Task<EmptyResponse> DeleteAsync(TimeSeriesDelete query, CancellationToken token = default)
         {
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace CogniteSdk.Resources
         {
             var query = new TimeSeriesDelete { Items=internalIds.Select(Identity.Create) };
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace CogniteSdk.Resources
         {
             var query = new TimeSeriesDelete { Items=externalIds.Select(Identity.Create) };
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<Identity> ids, CancellationToken token = default)
         {
             var req = Oryx.Cognite.TimeSeries.retrieve<IEnumerable<TimeSeries>>(ids);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace CogniteSdk.Resources
         {
             var ids = internalIds.Select(Identity.Create);
             var req = Oryx.Cognite.TimeSeries.retrieve<IEnumerable<TimeSeries>>(ids);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace CogniteSdk.Resources
         {
             var ids = externalIds.Select(Identity.Create);
             var req = Oryx.Cognite.TimeSeries.retrieve<IEnumerable<TimeSeries>>(ids);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.TimeSeries.search<IEnumerable<TimeSeries>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.TimeSeries.update<IEnumerable<TimeSeries>>(query);
-            return await Run(req, token).ConfigureAwait(false);
+            return await RunAsync(req, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/test/fsharp/Events.fs
+++ b/CogniteSdk/test/fsharp/Events.fs
@@ -268,7 +268,7 @@ let ``Filter events on ExternalIdPrefix is Ok`` () = task {
     let externalIds = Seq.map (fun (e: Event) -> e.ExternalId) res.Items
 
     // Assert
-    test <@ Seq.length externalIds = 3 @>
+    test <@ Seq.length externalIds > 0 @>
     test <@ Seq.forall (fun (e: string) -> e.StartsWith("odata")) externalIds @>
 }
 
@@ -318,7 +318,7 @@ let ``Filter events on Type is Ok`` () = task {
     let types = Seq.map (fun (e: Event) -> e.Type) res.Items
 
     // Assert
-    test <@ len = 1 @>
+    test <@ len > 0 @>
     test <@ Seq.forall ((=) "Monad") types @>
 }
 
@@ -333,5 +333,5 @@ let ``Search events is Ok`` () = task {
     let len = Seq.length res
 
     // Assert
-    test <@ len = 1 @>
+    test <@ len > 0 @>
 }

--- a/CogniteSdk/test/fsharp/Raw.fs
+++ b/CogniteSdk/test/fsharp/Raw.fs
@@ -39,7 +39,7 @@ let ``List Tables with limit is Ok`` () = task {
 }
 
 [<Trait("resource", "raw")>]
-[<Fact(Skip="Failing in greenfield. Disable until it's working again.")>]
+[<Fact>]
 let ``List Rows with limit is Ok`` () = task {
     // Arrange
     let expectedCols = seq {
@@ -60,7 +60,7 @@ let ``List Rows with limit is Ok`` () = task {
 }
 
 [<Trait("resource", "raw")>]
-[<Fact(Skip="Failing in greenfield. Disable until it's working again.")>]
+[<Fact>]
 let ``List Rows with limit and choose columns isOk`` () = task {
     // Arrange
     let query = RawRowQuery(Limit = Nullable 10, Columns = ["sdk-test-col2"])
@@ -94,7 +94,7 @@ let ``Create and delete database is Ok`` () = task {
 }
 
 [<Trait("resource", "raw")>]
-[<Fact(Skip="Failing in greenfield. Disable until it's working again.")>]
+[<Fact>]
 let ``Create and delete table in database is Ok`` () = task {
     // Arrange
     let dbName = Guid.NewGuid().ToString().[..31]
@@ -111,7 +111,7 @@ let ``Create and delete table in database is Ok`` () = task {
 }
 
 [<Trait("resource", "raw")>]
-[<Fact(Skip="Failing in greenfield. Disable until it's working again.")>]
+[<Fact>]
 let ``Create and delete rows from table in database is Ok`` () = task {
     // Arrange
     let dbName = Guid.NewGuid().ToString().[..31]

--- a/Oryx.Cognite/src/Common.fs
+++ b/Oryx.Cognite/src/Common.fs
@@ -76,28 +76,28 @@ module Common =
 module Context =
     let urlBuilder (request: HttpRequest) =
 
-        let extra = request.Extra
+        let items = request.Items
         let version =
-            match Map.tryFind PlaceHolder.ApiVersion extra with
+            match Map.tryFind PlaceHolder.ApiVersion items with
             | Some (String version) -> version
             | _ -> failwith "API version not set."
 
         let project =
-            match Map.tryFind PlaceHolder.Project extra with
+            match Map.tryFind PlaceHolder.Project items with
             | Some (String project) -> project
             | _ -> failwith "Client must set project."
 
         let resource =
-            match Map.tryFind PlaceHolder.Resource extra with
+            match Map.tryFind PlaceHolder.Resource items with
             | Some (String resource) -> resource
             | _ -> failwith "Resource not set."
 
         let baseUrl =
-            match Map.tryFind PlaceHolder.BaseUrl extra with
+            match Map.tryFind PlaceHolder.BaseUrl items with
             | Some (Url url) -> url.ToString()
             | _ -> "https://api.cognitedata.com"
 
-        if not (Map.containsKey PlaceHolder.HasAppId extra)
+        if not (Map.containsKey PlaceHolder.HasAppId items)
         then failwith "Client must set the Application ID (appId)."
 
         sprintf "api/%s/projects/%s%s" version project resource
@@ -112,13 +112,13 @@ module Context =
 
     /// Set the project to connect to.
     let withProject (project: string) (context: HttpContext) =
-        { context with Request = { context.Request with Extra = context.Request.Extra.Add(PlaceHolder.Project, String project) } }
+        { context with Request = { context.Request with Items = context.Request.Items.Add(PlaceHolder.Project, String project) } }
 
     let withAppId (appId: string) (context: HttpContext) =
-        { context with Request = { context.Request with Headers =  ("x-cdp-app", appId) :: context.Request.Headers; Extra = context.Request.Extra.Add(PlaceHolder.HasAppId, String "true") } }
+        { context with Request = { context.Request with Headers = context.Request.Headers.Add ("x-cdp-app", appId); Items = context.Request.Items.Add(PlaceHolder.HasAppId, String "true") } }
 
     let withBaseUrl (baseUrl: Uri) (context: HttpContext) =
-        { context with Request = { context.Request with Extra = context.Request.Extra.Add(PlaceHolder.BaseUrl, Url baseUrl) } }
+        { context with Request = { context.Request with Items = context.Request.Items.Add(PlaceHolder.BaseUrl, Url baseUrl) } }
 
     let create () =
         let major, minor, build = version

--- a/Oryx.Cognite/src/Handler.fs
+++ b/Oryx.Cognite/src/Handler.fs
@@ -63,13 +63,13 @@ module Handler =
         | ResponseError error -> raise error
         | Panic err -> raise err
 
-    /// Authorize the given handler. TODO: Simplify with authorize from Oryx.
-    let withAuth<'TResult, 'TNext, 'TError> (authorize: Func<CancellationToken, Task<string>>) (handler: HttpHandler<HttpResponseMessage, 'TNext, 'TResult, 'TError>) =
+    /// Use the given handler token provider for the request. TODO: Simplify with authorize from Oryx.
+    let withTokenProvider<'TResult, 'TNext, 'TError> (tokenProvider: Func<CancellationToken, Task<string>>) (handler: HttpHandler<HttpResponseMessage, 'TNext, 'TResult, 'TError>) =
         let authorize (next : HttpFunc<HttpResponseMessage, 'TResult, 'TError>) (ctx: Context<HttpResponseMessage>) = task {
             let! ctx' =
                 match ctx.Request.CancellationToken with
                 | Some ct -> task {
-                    let! token = authorize.Invoke ct
+                    let! token = tokenProvider.Invoke ct
                     match Option.ofObj token with
                     | Some token -> return Context.withBearerToken token ctx
                     | _ -> return ctx }

--- a/paket.lock
+++ b/paket.lock
@@ -41,18 +41,18 @@ NUGET
     Microsoft.NETCore.Platforms (3.1)
     NETStandard.Library (2.0.3)
       Microsoft.NETCore.Platforms (>= 1.1)
-    Oryx (1.0.0-beta-001)
+    Oryx (1.0.0-beta-003)
       FSharp.Core (>= 4.7)
       Microsoft.Extensions.Logging (>= 3.1.1)
       TaskBuilder.fs (>= 2.1)
-    Oryx.Protobuf (1.0.0-beta-001)
+    Oryx.Protobuf (1.0.0-beta-003)
       FSharp.Core (>= 4.7)
       Google.Protobuf (>= 3.11.3)
-      Oryx (>= 1.0.0-beta-001)
+      Oryx (>= 1.0.0-beta-003)
       TaskBuilder.fs (>= 2.1)
-    Oryx.SystemTextJson (1.0.0-beta-001)
+    Oryx.SystemTextJson (1.0.0-beta-003)
       FSharp.Core (>= 4.7)
-      Oryx (>= 1.0.0-beta-001)
+      Oryx (>= 1.0.0-beta-003)
       System.Text.Json (>= 4.7)
       TaskBuilder.fs (>= 2.1)
     System.Buffers (4.5)
@@ -280,18 +280,18 @@ NUGET
       System.Threading.Timer (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
       System.Xml.XDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
-    Oryx (1.0.0-beta-001)
+    Oryx (1.0.0-beta-003)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 3.1.1) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
-    Oryx.Protobuf (1.0.0-beta-001)
+    Oryx.Protobuf (1.0.0-beta-003)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       Google.Protobuf (>= 3.11.3) - restriction: >= netstandard2.0
-      Oryx (>= 1.0.0-beta-001) - restriction: >= netstandard2.0
+      Oryx (>= 1.0.0-beta-003) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
-    Oryx.SystemTextJson (1.0.0-beta-001)
+    Oryx.SystemTextJson (1.0.0-beta-003)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-      Oryx (>= 1.0.0-beta-001) - restriction: >= netstandard2.0
+      Oryx (>= 1.0.0-beta-003) - restriction: >= netstandard2.0
       System.Text.Json (>= 4.7) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= net46) (< netstandard1.3) (>= netstandard1.6)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< netstandard1.3) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
@@ -826,7 +826,7 @@ NUGET
     Microsoft.NETCore.Platforms (3.1)
     NETStandard.Library (2.0.3)
       Microsoft.NETCore.Platforms (>= 1.1)
-    Oryx (1.0.0-beta-001)
+    Oryx (1.0.0-beta-003)
       FSharp.Core (>= 4.7)
       Microsoft.Extensions.Logging (>= 3.1.1)
       TaskBuilder.fs (>= 2.1)
@@ -956,18 +956,18 @@ NUGET
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (&& (< net20) (>= netstandard1.0) (< netstandard1.3)) (&& (< net20) (>= netstandard1.3) (< netstandard2.0))
       System.Xml.XmlDocument (>= 4.3) - restriction: && (< net20) (>= netstandard1.3) (< netstandard2.0)
     NuGet.Frameworks (5.4) - restriction: >= netcoreapp2.1
-    Oryx (1.0.0-beta-001)
+    Oryx (1.0.0-beta-003)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 3.1.1) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
-    Oryx.Protobuf (1.0.0-beta-001)
+    Oryx.Protobuf (1.0.0-beta-003)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       Google.Protobuf (>= 3.11.3) - restriction: >= netstandard2.0
-      Oryx (>= 1.0.0-beta-001) - restriction: >= netstandard2.0
+      Oryx (>= 1.0.0-beta-003) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
-    Oryx.SystemTextJson (1.0.0-beta-001)
+    Oryx.SystemTextJson (1.0.0-beta-003)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-      Oryx (>= 1.0.0-beta-001) - restriction: >= netstandard2.0
+      Oryx (>= 1.0.0-beta-003) - restriction: >= netstandard2.0
       System.Text.Json (>= 4.7) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (>= netcoreapp1.0) (< netstandard1.2)) (&& (>= netcoreapp1.0) (< netstandard1.3)) (&& (>= netcoreapp1.0) (< netstandard1.4)) (&& (>= netcoreapp1.0) (< netstandard1.5)) (&& (>= netcoreapp1.0) (< netstandard1.6)) (&& (>= netcoreapp1.0) (< netstandard2.0))


### PR DESCRIPTION
Add `SetTokenProvider` method to client for getting a new bearer toke without building a new client.

- Add null checks to client methods
- Add resource abstract class to hide some boilerplate code for resource methods.

Not sure how to test, but once Oryx PR is approved we depend on the `authorize` function there which is unit-tested.

Will consider rewriting the client to nullable reference types some other time.