### PR TITLE
Add missing file search

### DIFF
--- a/CogniteSdk.Types/Assets/Asset.cs
+++ b/CogniteSdk.Types/Assets/Asset.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Asset read DTO.
+    /// The Asset read class.
     /// </summary>
     public class Asset
     {

--- a/CogniteSdk.Types/Assets/AssetCreate.cs
+++ b/CogniteSdk.Types/Assets/AssetCreate.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Dto for creating a new asset.
+    /// Class for creating a new asset.
     /// </summary>
     public class AssetCreate
     {

--- a/CogniteSdk.Types/Assets/AssetDelete.cs
+++ b/CogniteSdk.Types/Assets/AssetDelete.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The event delete DTO.
+    /// The event delete class.
     /// </summary>
     public class AssetDelete : ItemsWithoutCursor<Identity>
     {

--- a/CogniteSdk.Types/Assets/AssetFilter.cs
+++ b/CogniteSdk.Types/Assets/AssetFilter.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The asset filter DTO.
+    /// The asset filter class.
     /// </summary>
     public class AssetFilter
     {

--- a/CogniteSdk.Types/Assets/AssetQuery.cs
+++ b/CogniteSdk.Types/Assets/AssetQuery.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Asset query DTO.
+    /// The Asset query class.
     /// </summary>
     public class AssetQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Assets/AssetSearch.cs
+++ b/CogniteSdk.Types/Assets/AssetSearch.cs
@@ -6,7 +6,7 @@ namespace CogniteSdk
     /// <summary>
     /// The sequence search DTO.
     /// </summary>
-    public class AssetSearch : SearchQueryDto<AssetFilter, Search> {
+    public class AssetSearch : SearchQuery<AssetFilter, Search> {
 
         /// <summary>
         /// Create a new empty Asset search DTO with pre-initialized emtpy Filter and Search.

--- a/CogniteSdk.Types/Assets/AssetSearch.cs
+++ b/CogniteSdk.Types/Assets/AssetSearch.cs
@@ -4,12 +4,12 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// The sequence search DTO.
+    /// The sequence search type.
     /// </summary>
     public class AssetSearch : SearchQuery<AssetFilter, Search> {
 
         /// <summary>
-        /// Create a new empty Asset search DTO with pre-initialized emtpy Filter and Search.
+        /// Create a new empty Asset search object with pre-initialized emtpy Filter and Search.
         /// </summary>
         /// <returns>New instance of the AssetSearch.</returns>
         public static AssetSearch Empty ()

--- a/CogniteSdk.Types/Assets/AssetUpdate.cs
+++ b/CogniteSdk.Types/Assets/AssetUpdate.cs
@@ -3,7 +3,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Asset update DTO.
+    /// The Asset update type.
     /// </summary>
     public class AssetUpdate
     {
@@ -53,7 +53,7 @@ namespace CogniteSdk
     }
 
     /// <summary>
-    /// The asset update item DTO. Contains the update item for an <see cref="AssetUpdate">AssetUpdate</see>.
+    /// The asset update item type. Contains the update item for an <see cref="AssetUpdate">AssetUpdate</see>.
     /// </summary>
     public class AssetUpdateItem : UpdateItem<AssetUpdate>
     {

--- a/CogniteSdk.Types/Assets/AssetUpdate.cs
+++ b/CogniteSdk.Types/Assets/AssetUpdate.cs
@@ -3,7 +3,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Asset update type.
+    /// The Asset update class.
     /// </summary>
     public class AssetUpdate
     {

--- a/CogniteSdk.Types/Common/ResponseError.cs
+++ b/CogniteSdk.Types/Common/ResponseError.cs
@@ -8,10 +8,10 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The DTO for errors received from CDF. Used for decoding API errors. Should not be used in user code. SDK will
-    /// convert it directly to a ResponseException.
+    /// Class for handling errors received from CDF. Used for decoding API errors. Should not be used in user code. SDK
+    /// will convert it directly to a ResponseException.
     /// </summary>
-    public class ResponseErrorDto
+    public class ResponseError
     {
         /// <summary>
         ///  The API error code (HTTP error code)
@@ -38,15 +38,15 @@ namespace CogniteSdk
     }
 
     /// <summary>
-    /// The DTO for errors received from CDF. Used for decoding API errors. Should not be used in user code. SDK will
+    /// The type for errors received from CDF. Used for decoding API errors. Should not be used in user code. SDK will
     /// convert it directly to a ResponseException.
     /// </summary>
-    public class ApiResponseErrorDto
+    public class ApiResponseError
     {
         /// <summary>
         /// Response error object.
         /// </summary>
-        public ResponseErrorDto Error { get; set; }
+        public ResponseError Error { get; set; }
 
         /// <summary>
         /// Unique id for the request.

--- a/CogniteSdk.Types/Common/Search.cs
+++ b/CogniteSdk.Types/Common/Search.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Search query DTO. Shared between the various resource search functions.
+    /// Search query type. Shared between the various resource search functions.
     /// </summary>
     public class Search
     {

--- a/CogniteSdk.Types/Common/Search.cs
+++ b/CogniteSdk.Types/Common/Search.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Search query type. Shared between the various resource search functions.
+    /// Search query class. Shared between the various resource search functions.
     /// </summary>
     public class Search
     {

--- a/CogniteSdk.Types/Common/SearchQuery.cs
+++ b/CogniteSdk.Types/Common/SearchQuery.cs
@@ -10,7 +10,7 @@ namespace CogniteSdk
     /// </summary>
     /// <typeparam name="TFilter">Filter type</typeparam>
     /// <typeparam name="TSearch">Search type</typeparam>
-    public class SearchQueryDto<TFilter, TSearch>
+    public class SearchQuery<TFilter, TSearch>
     {
         /// <summary>
         /// Filter on items with strict matching.

--- a/CogniteSdk.Types/Common/UpdateItem.cs
+++ b/CogniteSdk.Types/Common/UpdateItem.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Update item for a given property.
+    /// Update class for a given property.
     /// </summary>
     /// <typeparam name="TUpdate">Type of object to update.</typeparam>
     public class UpdateItem<TUpdate> : Identity

--- a/CogniteSdk.Types/DataPoints/DataPoint.cs
+++ b/CogniteSdk.Types/DataPoints/DataPoint.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The data point DTO for each individual data point.
+    /// The data point class for each individual data point.
     /// </summary>
     public class DataPoint
     {

--- a/CogniteSdk.Types/DataPoints/DataPointAggregatet.cs
+++ b/CogniteSdk.Types/DataPoints/DataPointAggregatet.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The aggregate data point DTO.
+    /// The aggregate data point class.
     /// </summary>
     public class DataPointAggregate
     {

--- a/CogniteSdk.Types/DataPoints/DataPointsCreate.cs
+++ b/CogniteSdk.Types/DataPoints/DataPointsCreate.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Data Points write type
+    /// Data Points write class.
     /// </summary>
     public class DataPointsCreate
     {

--- a/CogniteSdk.Types/DataPoints/DataPointsDelete.cs
+++ b/CogniteSdk.Types/DataPoints/DataPointsDelete.cs
@@ -37,7 +37,7 @@ namespace CogniteSdk
     }
 
     /// <summary>
-    /// Data Points delete DTO.
+    /// Data Points delete type.
     /// </summary>
     public class DataPointsDelete : ItemsWithoutCursor<IdentityWithRange> {}
 }

--- a/CogniteSdk.Types/DataPoints/DataPointsItem.cs
+++ b/CogniteSdk.Types/DataPoints/DataPointsItem.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Data Points item type.
+    /// Data Points item class.
     /// </summary>
     public class DataPointsItem<T>
     {

--- a/CogniteSdk.Types/DataPoints/DataPointsItem.cs
+++ b/CogniteSdk.Types/DataPoints/DataPointsItem.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Data Points DTO.
+    /// Data Points item type.
     /// </summary>
     public class DataPointsItem<T>
     {

--- a/CogniteSdk.Types/DataPoints/DataPointsLatestQuery.cs
+++ b/CogniteSdk.Types/DataPoints/DataPointsLatestQuery.cs
@@ -6,7 +6,8 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The data points query for each individual data point query within the top-level <see cref="DataPointsQuery">DataPointsQuery</see>.
+    /// The data points query for each individual data point query within the
+    /// top-level <see cref="DataPointsQuery">DataPointsQuery</see>.
     /// </summary>
     public class IdentityWithBefore : Identity
     {

--- a/CogniteSdk.Types/Events/Event.cs
+++ b/CogniteSdk.Types/Events/Event.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Event read entity.
+    /// The Event read class.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Warning", "CA1716: Identifiers should not match keywords", Justification = "We also have events")]
     public class Event

--- a/CogniteSdk.Types/Events/EventCreate.cs
+++ b/CogniteSdk.Types/Events/EventCreate.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The event write DTO.
+    /// The event write class.
     /// </summary>
     public class EventCreate
     {

--- a/CogniteSdk.Types/Events/EventDelete.cs
+++ b/CogniteSdk.Types/Events/EventDelete.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Events delete DTO.
+    /// Events delete class.
     /// </summary>
     public class EventDelete : ItemsWithoutCursor<Identity>
     {

--- a/CogniteSdk.Types/Events/EventFilter.cs
+++ b/CogniteSdk.Types/Events/EventFilter.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Event filter DTO.
+    /// The Event filter class.
     /// </summary>
     public class EventFilter
     {

--- a/CogniteSdk.Types/Events/EventQuery.cs
+++ b/CogniteSdk.Types/Events/EventQuery.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Event query DTO.
+    /// The Event query class.
     /// </summary>
     public class EventQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Events/EventSearch.cs
+++ b/CogniteSdk.Types/Events/EventSearch.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Dto for description search
+    /// The description search class.
     /// </summary>
     public class DescriptionSearch
     {
@@ -21,7 +21,7 @@ namespace CogniteSdk
     }
 
     /// <summary>
-    /// The event search DTO.
+    /// The event search class.
     /// </summary>
     public class EventSearch : SearchQuery<EventFilter, DescriptionSearch> {
 

--- a/CogniteSdk.Types/Events/EventSearch.cs
+++ b/CogniteSdk.Types/Events/EventSearch.cs
@@ -23,7 +23,7 @@ namespace CogniteSdk
     /// <summary>
     /// The event search DTO.
     /// </summary>
-    public class EventSearch : SearchQueryDto<EventFilter, DescriptionSearch> {
+    public class EventSearch : SearchQuery<EventFilter, DescriptionSearch> {
 
         /// <summary>
         /// Create a new empty Event search DTO with pre-initialized emtpy Filter and Search.

--- a/CogniteSdk.Types/Events/EventUpdate.cs
+++ b/CogniteSdk.Types/Events/EventUpdate.cs
@@ -3,7 +3,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The event update DTO.
+    /// The event update type.
     /// </summary>
     public class EventUpdate
     {

--- a/CogniteSdk.Types/Events/EventUpdate.cs
+++ b/CogniteSdk.Types/Events/EventUpdate.cs
@@ -3,7 +3,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The event update type.
+    /// The event update class.
     /// </summary>
     public class EventUpdate
     {

--- a/CogniteSdk.Types/Files/File.cs
+++ b/CogniteSdk.Types/Files/File.cs
@@ -9,7 +9,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// File read response resource.
+    /// File read response class.
     /// </summary>
     public class File
     {

--- a/CogniteSdk.Types/Files/FileCreate.cs
+++ b/CogniteSdk.Types/Files/FileCreate.cs
@@ -9,7 +9,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// File write response resource.
+    /// File write response class.
     /// </summary>
     public class FileCreate
     {

--- a/CogniteSdk.Types/Files/FileDelete.cs
+++ b/CogniteSdk.Types/Files/FileDelete.cs
@@ -4,7 +4,7 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// FIle delete type.
+    /// File delete class.
     /// </summary>
     public class FileDelete : ItemsWithoutCursor<Identity> { }
 }

--- a/CogniteSdk.Types/Files/FileDelete.cs
+++ b/CogniteSdk.Types/Files/FileDelete.cs
@@ -4,7 +4,7 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// FIle delete DTO.
+    /// FIle delete type.
     /// </summary>
     public class FileDelete : ItemsWithoutCursor<Identity> { }
 }

--- a/CogniteSdk.Types/Files/FileDownload.cs
+++ b/CogniteSdk.Types/Files/FileDownload.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// File download response with Url.
+    /// File download response class with Url.
     /// </summary>
     public class FileDownload
     {

--- a/CogniteSdk.Types/Files/FileFilter.cs
+++ b/CogniteSdk.Types/Files/FileFilter.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The File query DTO.
+    /// The File query type.
     /// </summary>
     public class FileFilter
     {

--- a/CogniteSdk.Types/Files/FileFilter.cs
+++ b/CogniteSdk.Types/Files/FileFilter.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The File query type.
+    /// The File query class.
     /// </summary>
     public class FileFilter
     {

--- a/CogniteSdk.Types/Files/FileQuery.cs
+++ b/CogniteSdk.Types/Files/FileQuery.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The File query DTO.
+    /// The File query type.
     /// </summary>
     public class FileQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Files/FileQuery.cs
+++ b/CogniteSdk.Types/Files/FileQuery.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The File query type.
+    /// The File query class.
     /// </summary>
     public class FileQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Files/FileSearch.cs
+++ b/CogniteSdk.Types/Files/FileSearch.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// File search name query.
+    /// File search name query class.
     /// </summary>
     public class NameSearch
     {
@@ -20,7 +20,7 @@ namespace CogniteSdk
     }
 
     /// <summary>
-    /// File search query.
+    /// File search query class.
     /// </summary>
     public class FileSearch : SearchQuery<FileFilter, NameSearch>
     {

--- a/CogniteSdk.Types/Files/FileSearch.cs
+++ b/CogniteSdk.Types/Files/FileSearch.cs
@@ -3,12 +3,12 @@
 
 using CogniteSdk.Types.Common;
 
-namespace CogniteSdk.Files
+namespace CogniteSdk
 {
     /// <summary>
-    /// File search query DTO.
+    /// File search name query.
     /// </summary>
-    public class FileSearch
+    public class NameSearch
     {
         /// <summary>
         /// Prefix and fuzzy search on name.
@@ -18,4 +18,23 @@ namespace CogniteSdk.Files
         /// <inheritdoc />
         public override string ToString() => Stringable.ToString(this);
     }
+
+    /// <summary>
+    /// File search query.
+    /// </summary>
+    public class FileSearch : SearchQuery<FileFilter, NameSearch>
+    {
+        /// <summary>
+        /// Create a new empty File search with pre-initialized emtpy Filter and Search.
+        /// </summary>
+        /// <returns>New instance of the FileSearch.</returns>
+        public static FileSearch Empty ()
+        {
+            return new FileSearch {
+                Filter=new FileFilter(),
+                Search=new NameSearch()
+            };
+        }
+    }
 }
+

--- a/CogniteSdk.Types/Files/FileUpdate.cs
+++ b/CogniteSdk.Types/Files/FileUpdate.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The file update DTO.
+    /// The file update type.
     /// </summary>
     public class FileUpdate
     {

--- a/CogniteSdk.Types/Files/FileUpdate.cs
+++ b/CogniteSdk.Types/Files/FileUpdate.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The file update type.
+    /// The file update class.
     /// </summary>
     public class FileUpdate
     {
@@ -57,7 +57,7 @@ namespace CogniteSdk
     }
 
     /// <summary>
-    /// The file update item DTO. Contains the update item for an <see cref="FileUpdate">FileUpdate</see>.
+    /// The file update item class. Contains the update item for an <see cref="FileUpdate">FileUpdate</see>.
     /// </summary>
     public class FileUpdateItem : UpdateItem<FileUpdate>
     {

--- a/CogniteSdk.Types/Files/FileUploadRead.cs
+++ b/CogniteSdk.Types/Files/FileUploadRead.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// File upload read response resource.
+    /// File upload read response class.
     /// </summary>
     public class FileUploadRead : File
     {

--- a/CogniteSdk.Types/Login/LoginDataRead.cs
+++ b/CogniteSdk.Types/Login/LoginDataRead.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk.Login
 {
     /// <summary>
-    /// The Login Data Read DTO.
+    /// The Login Data Read type.
     /// </summary>
     public class LoginDataRead
     {

--- a/CogniteSdk.Types/Login/LoginDataRead.cs
+++ b/CogniteSdk.Types/Login/LoginDataRead.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk.Login
 {
     /// <summary>
-    /// The Login Data Read type.
+    /// The Login data read class.
     /// </summary>
     public class LoginDataRead
     {

--- a/CogniteSdk.Types/Login/LoginStatus.cs
+++ b/CogniteSdk.Types/Login/LoginStatus.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk.Login
 {
     /// <summary>
-    /// The Login Status Read type.
+    /// The Login Status Read class.
     /// </summary>
     public class LoginStatus
     {

--- a/CogniteSdk.Types/Login/LoginStatus.cs
+++ b/CogniteSdk.Types/Login/LoginStatus.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk.Login
 {
     /// <summary>
-    /// The Login Status Read DTO.
+    /// The Login Status Read type.
     /// </summary>
     public class LoginStatus
     {

--- a/CogniteSdk.Types/Raw/RawDatabase.cs
+++ b/CogniteSdk.Types/Raw/RawDatabase.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Raw database object.
+    /// Raw database class.
     /// </summary>
     public class RawDatabase
     {

--- a/CogniteSdk.Types/Raw/RawDatabaseDelete.cs
+++ b/CogniteSdk.Types/Raw/RawDatabaseDelete.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Databases delete DTO.
+    /// Databases delete class.
     /// </summary>
     public class RawDatabaseDelete : ItemsWithoutCursor<RawDatabase>
     {

--- a/CogniteSdk.Types/Raw/RawDatabaseQuery.cs
+++ b/CogniteSdk.Types/Raw/RawDatabaseQuery.cs
@@ -4,7 +4,7 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// The database query DTO.
+    /// The Raw database query type.
     /// </summary>
     public class RawDatabaseQuery : CursorQueryBase { }
 }

--- a/CogniteSdk.Types/Raw/RawDatabaseQuery.cs
+++ b/CogniteSdk.Types/Raw/RawDatabaseQuery.cs
@@ -4,7 +4,7 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Raw database query type.
+    /// The Raw database query class.
     /// </summary>
     public class RawDatabaseQuery : CursorQueryBase { }
 }

--- a/CogniteSdk.Types/Raw/RawRow.cs
+++ b/CogniteSdk.Types/Raw/RawRow.cs
@@ -8,7 +8,7 @@ using System.Text.Json;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The row read type.
+    /// The row read class.
     /// </summary>
     public class RawRow
     {

--- a/CogniteSdk.Types/Raw/RawRow.cs
+++ b/CogniteSdk.Types/Raw/RawRow.cs
@@ -8,7 +8,7 @@ using System.Text.Json;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The row read DTO.
+    /// The row read type.
     /// </summary>
     public class RawRow
     {

--- a/CogniteSdk.Types/Raw/RawRowCreate.cs
+++ b/CogniteSdk.Types/Raw/RawRowCreate.cs
@@ -10,7 +10,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Dto to write a row to a table in Raw.
+    /// Class to write a row to a table in Raw.
     /// </summary>
     public class RawRowCreate
     {

--- a/CogniteSdk.Types/Raw/RawRowDelete.cs
+++ b/CogniteSdk.Types/Raw/RawRowDelete.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Dto with keys of rows to delete in table.
+    /// Class with keys of rows to delete in table.
     /// </summary>
     public class RawRowDelete
     {

--- a/CogniteSdk.Types/Raw/RawRowQuery.cs
+++ b/CogniteSdk.Types/Raw/RawRowQuery.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The row query DTO.
+    /// The Raw row query type.
     /// </summary>
     public class RawRowQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Raw/RawRowQuery.cs
+++ b/CogniteSdk.Types/Raw/RawRowQuery.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Raw row query type.
+    /// The Raw row query class.
     /// </summary>
     public class RawRowQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Raw/RawTable.cs
+++ b/CogniteSdk.Types/Raw/RawTable.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Raw table object.
+    /// Raw table class.
     /// </summary>
     public class RawTable
     {

--- a/CogniteSdk.Types/Raw/RawTableDelete.cs
+++ b/CogniteSdk.Types/Raw/RawTableDelete.cs
@@ -4,7 +4,7 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// Databases delete DTO.
+    /// Databases delete type.
     /// </summary>
     public class RawTableDelete : ItemsWithoutCursor<RawTable> { }
 }

--- a/CogniteSdk.Types/Raw/RawTableDelete.cs
+++ b/CogniteSdk.Types/Raw/RawTableDelete.cs
@@ -4,7 +4,7 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// Databases delete type.
+    /// Databases delete class.
     /// </summary>
     public class RawTableDelete : ItemsWithoutCursor<RawTable> { }
 }

--- a/CogniteSdk.Types/Relationships/Relationship.cs
+++ b/CogniteSdk.Types/Relationships/Relationship.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Dto for reading relationship.
+    /// Class for reading relationship.
     /// </summary>
     public class Relationship
     {

--- a/CogniteSdk.Types/Relationships/RelationshipCreate.cs
+++ b/CogniteSdk.Types/Relationships/RelationshipCreate.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Dto for writing relationship.
+    /// Class for writing relationship.
     /// </summary>
     public class RelationshipCreate
     {

--- a/CogniteSdk.Types/Relationships/RelationshipFilter.cs
+++ b/CogniteSdk.Types/Relationships/RelationshipFilter.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Dto for filtering relationships.
+    /// Class for filtering relationships.
     /// </summary>
     public class RelationshipFilter
     {

--- a/CogniteSdk.Types/Relationships/RelationshipVertexProperty.cs
+++ b/CogniteSdk.Types/Relationships/RelationshipVertexProperty.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Vertex property dto.
+    /// Relationships Vertex property.
     /// </summary>
     public class RelationshipVertexProperty
     {

--- a/CogniteSdk.Types/Relationships/RestrictedGraphQuery.cs
+++ b/CogniteSdk.Types/Relationships/RestrictedGraphQuery.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Dto to perform a graph query.
+    /// Class to perform a graph query.
     /// </summary>
     public class RestrictedGraphQuery
     {

--- a/CogniteSdk.Types/Relationships/RestrictedGraphQueryResult.cs
+++ b/CogniteSdk.Types/Relationships/RestrictedGraphQueryResult.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Type to perform a graph query.
+    /// Class to perform a graph query.
     /// </summary>
     public class RestrictedGraphQueryResult
     {

--- a/CogniteSdk.Types/Relationships/RestrictedGraphQueryResult.cs
+++ b/CogniteSdk.Types/Relationships/RestrictedGraphQueryResult.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Dto to perform a graph query.
+    /// Type to perform a graph query.
     /// </summary>
     public class RestrictedGraphQueryResult
     {

--- a/CogniteSdk.Types/Sequences/Rows/SequenceData.cs
+++ b/CogniteSdk.Types/Sequences/Rows/SequenceData.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence Data Read DTO.
+    /// The Sequence Data Read.
     /// </summary>
     public class SequenceData
     {

--- a/CogniteSdk.Types/Sequences/Rows/SequenceData.cs
+++ b/CogniteSdk.Types/Sequences/Rows/SequenceData.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence Data Read.
+    /// The Sequence data read class.
     /// </summary>
     public class SequenceData
     {

--- a/CogniteSdk.Types/Sequences/Rows/SequenceDataCreate.cs
+++ b/CogniteSdk.Types/Sequences/Rows/SequenceDataCreate.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence Data create class
+    /// The Sequence data create class
     /// </summary>
     public class SequenceDataCreate
     {

--- a/CogniteSdk.Types/Sequences/Rows/SequenceRow.cs
+++ b/CogniteSdk.Types/Sequences/Rows/SequenceRow.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence row DTO. Contains row number and values in the order defined by the columns.
+    /// The Sequence row class. Contains row number and values in the order defined by the columns.
     /// </summary>
     public class SequenceRow
     {

--- a/CogniteSdk.Types/Sequences/Rows/SequenceRowDelete.cs
+++ b/CogniteSdk.Types/Sequences/Rows/SequenceRowDelete.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence row delete DTO.
+    /// The Sequence row delete.
     /// </summary>
     public class SequenceRowDelete
     {

--- a/CogniteSdk.Types/Sequences/Rows/SequenceRowDelete.cs
+++ b/CogniteSdk.Types/Sequences/Rows/SequenceRowDelete.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence row delete.
+    /// The Sequence row delete class.
     /// </summary>
     public class SequenceRowDelete
     {

--- a/CogniteSdk.Types/Sequences/Rows/SequenceRowQuery.cs
+++ b/CogniteSdk.Types/Sequences/Rows/SequenceRowQuery.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence row query.
+    /// The Sequence row query class.
     /// </summary>
     public class SequenceRowQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Sequences/Rows/SequenceRowQuery.cs
+++ b/CogniteSdk.Types/Sequences/Rows/SequenceRowQuery.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence row query DTO.
+    /// The Sequence row query.
     /// </summary>
     public class SequenceRowQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Sequences/Sequence.cs
+++ b/CogniteSdk.Types/Sequences/Sequence.cs
@@ -9,7 +9,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Sequence type for reading sequences.
+    /// Sequence class for reading sequences.
     /// </summary>
     public class Sequence
     {

--- a/CogniteSdk.Types/Sequences/Sequence.cs
+++ b/CogniteSdk.Types/Sequences/Sequence.cs
@@ -9,7 +9,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Sequence DTO for reading sequences.
+    /// Sequence type for reading sequences.
     /// </summary>
     public class Sequence
     {

--- a/CogniteSdk.Types/Sequences/SequenceColumn.cs
+++ b/CogniteSdk.Types/Sequences/SequenceColumn.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence column DTO.
+    /// The Sequence column.
     /// </summary>
     public class SequenceColumn
     {

--- a/CogniteSdk.Types/Sequences/SequenceColumn.cs
+++ b/CogniteSdk.Types/Sequences/SequenceColumn.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence column.
+    /// The Sequence column class.
     /// </summary>
     public class SequenceColumn
     {

--- a/CogniteSdk.Types/Sequences/SequenceColumnInfo.cs
+++ b/CogniteSdk.Types/Sequences/SequenceColumnInfo.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The sequence column info.
+    /// The sequence column info class.
     /// </summary>
     public class SequenceColumnInfo
     {

--- a/CogniteSdk.Types/Sequences/SequenceColumnInfo.cs
+++ b/CogniteSdk.Types/Sequences/SequenceColumnInfo.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The sequence column info DTO.
+    /// The sequence column info.
     /// </summary>
     public class SequenceColumnInfo
     {

--- a/CogniteSdk.Types/Sequences/SequenceColumnWrite.cs
+++ b/CogniteSdk.Types/Sequences/SequenceColumnWrite.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence column DTO.
+    /// The Sequence column.
     /// </summary>
     public class SequenceColumnWrite
     {

--- a/CogniteSdk.Types/Sequences/SequenceColumnWrite.cs
+++ b/CogniteSdk.Types/Sequences/SequenceColumnWrite.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence column.
+    /// The Sequence column class.
     /// </summary>
     public class SequenceColumnWrite
     {

--- a/CogniteSdk.Types/Sequences/SequenceCreate.cs
+++ b/CogniteSdk.Types/Sequences/SequenceCreate.cs
@@ -9,7 +9,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Sequence type for writing.
+    /// Sequence class for writing.
     /// </summary>
     public class SequenceCreate
     {

--- a/CogniteSdk.Types/Sequences/SequenceCreate.cs
+++ b/CogniteSdk.Types/Sequences/SequenceCreate.cs
@@ -9,7 +9,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Sequence DTO for writing.
+    /// Sequence type for writing.
     /// </summary>
     public class SequenceCreate
     {

--- a/CogniteSdk.Types/Sequences/SequenceFilter.cs
+++ b/CogniteSdk.Types/Sequences/SequenceFilter.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence filter.
+    /// The Sequence filter class.
     /// </summary>
     public class SequenceFilter
     {

--- a/CogniteSdk.Types/Sequences/SequenceFilter.cs
+++ b/CogniteSdk.Types/Sequences/SequenceFilter.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence filter DTO.
+    /// The Sequence filter.
     /// </summary>
     public class SequenceFilter
     {

--- a/CogniteSdk.Types/Sequences/SequenceQuery.cs
+++ b/CogniteSdk.Types/Sequences/SequenceQuery.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence query DTO.
+    /// The Sequence query type.
     /// </summary>
     public class SequenceQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Sequences/SequenceQuery.cs
+++ b/CogniteSdk.Types/Sequences/SequenceQuery.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Sequence query type.
+    /// The Sequence query class.
     /// </summary>
     public class SequenceQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Sequences/SequenceSearch.cs
+++ b/CogniteSdk.Types/Sequences/SequenceSearch.cs
@@ -4,12 +4,12 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// The sequence search DTO.
+    /// The sequence search.
     /// </summary>
     public class SequenceSearch : SearchQuery<SequenceFilter, Search> {
 
         /// <summary>
-        /// Create a new pre-initialized Asset search DTO.
+        /// Create a new pre-initialized Asset search.
         /// </summary>
         /// <returns>New instance of the AssetSearch.</returns>
         public static SequenceSearch Empty ()

--- a/CogniteSdk.Types/Sequences/SequenceSearch.cs
+++ b/CogniteSdk.Types/Sequences/SequenceSearch.cs
@@ -6,7 +6,7 @@ namespace CogniteSdk
     /// <summary>
     /// The sequence search DTO.
     /// </summary>
-    public class SequenceSearch : SearchQueryDto<SequenceFilter, Search> {
+    public class SequenceSearch : SearchQuery<SequenceFilter, Search> {
 
         /// <summary>
         /// Create a new pre-initialized Asset search DTO.

--- a/CogniteSdk.Types/Sequences/SequenceSearch.cs
+++ b/CogniteSdk.Types/Sequences/SequenceSearch.cs
@@ -4,7 +4,7 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// The sequence search.
+    /// The sequence search class.
     /// </summary>
     public class SequenceSearch : SearchQuery<SequenceFilter, Search> {
 

--- a/CogniteSdk.Types/Sequences/SequenceUpdate.cs
+++ b/CogniteSdk.Types/Sequences/SequenceUpdate.cs
@@ -4,7 +4,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The sequence update DTO.
+    /// The sequence update.
     /// </summary>
     public class SequenceUpdate
     {

--- a/CogniteSdk.Types/Sequences/SequenceUpdate.cs
+++ b/CogniteSdk.Types/Sequences/SequenceUpdate.cs
@@ -4,7 +4,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The sequence update.
+    /// The sequence update class.
     /// </summary>
     public class SequenceUpdate
     {

--- a/CogniteSdk.Types/Sequences/SequenceUpdateItem.cs
+++ b/CogniteSdk.Types/Sequences/SequenceUpdateItem.cs
@@ -1,7 +1,7 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// The sequence update items DTO base class.
+    /// The sequence update items class base class.
     /// </summary>
     public class SequenceUpdateItem : UpdateItem<SequenceUpdate>
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeries.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeries.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// TimeSeries read entity.
+    /// TimeSeries read class.
     /// </summary>
     public class TimeSeries
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesCreate.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesCreate.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Timeseries write.
+    /// Timeseries write class.
     /// </summary>
     public class TimeSeriesCreate
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesCreate.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesCreate.cs
@@ -7,7 +7,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Timeseries write dto.
+    /// Timeseries write.
     /// </summary>
     public class TimeSeriesCreate
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesDelete.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesDelete.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// TimeSeries delete.
+    /// TimeSeries delete class.
     /// </summary>
     public class TimeSeriesDelete : ItemsWithoutCursor<Identity>
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesDelete.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesDelete.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// TimeSeries delete DTO.
+    /// TimeSeries delete.
     /// </summary>
     public class TimeSeriesDelete : ItemsWithoutCursor<Identity>
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesFilter.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesFilter.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The time series filter DTO.
+    /// The time series filter.
     /// </summary>
     public class TimeSeriesFilter
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesFilter.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesFilter.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The time series filter.
+    /// The time series filter class.
     /// </summary>
     public class TimeSeriesFilter
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesQuery.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesQuery.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The time series query DTO.
+    /// The time series query.
     /// </summary>
     public class TimeSeriesQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesQuery.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesQuery.cs
@@ -6,7 +6,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The time series query.
+    /// The time series query class.
     /// </summary>
     public class TimeSeriesQuery : CursorQueryBase
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesSearch.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesSearch.cs
@@ -6,7 +6,7 @@ namespace CogniteSdk
     /// <summary>
     /// The timeseries search DTO.
     /// </summary>
-    public class TimeSeriesSearch : SearchQueryDto<TimeSeriesFilter, Search> {
+    public class TimeSeriesSearch : SearchQuery<TimeSeriesFilter, Search> {
         /// <summary>
         /// Create a new empty TimeSeries search DTO with pre-initialized emtpy Filter and Search.
         /// </summary>

--- a/CogniteSdk.Types/Timeseries/TimeSeriesSearch.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesSearch.cs
@@ -4,7 +4,7 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// The timeseries search type.
+    /// The timeseries search type class.
     /// </summary>
     public class TimeSeriesSearch : SearchQuery<TimeSeriesFilter, Search> {
         /// <summary>

--- a/CogniteSdk.Types/Timeseries/TimeSeriesSearch.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesSearch.cs
@@ -4,13 +4,13 @@
 namespace CogniteSdk
 {
     /// <summary>
-    /// The timeseries search DTO.
+    /// The timeseries search type.
     /// </summary>
     public class TimeSeriesSearch : SearchQuery<TimeSeriesFilter, Search> {
         /// <summary>
-        /// Create a new empty TimeSeries search DTO with pre-initialized emtpy Filter and Search.
+        /// Create a new empty TimeSeries search with pre-initialized emtpy Filter and Search.
         /// </summary>
-        /// <returns>New instance of the EventSearch.</returns>
+        /// <returns>New instance of the TimeSeriesSearch.</returns>
         public static TimeSeriesSearch Empty ()
         {
             return new TimeSeriesSearch {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesUpdate.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesUpdate.cs
@@ -3,7 +3,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The time series update type.
+    /// The time series update class.
     /// </summary>
     public class TimeSeriesUpdate
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeriesUpdate.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesUpdate.cs
@@ -3,7 +3,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The time series update DTO.
+    /// The time series update type.
     /// </summary>
     public class TimeSeriesUpdate
     {

--- a/CogniteSdk/src/Resources/Files.cs
+++ b/CogniteSdk/src/Resources/Files.cs
@@ -248,6 +248,23 @@ namespace CogniteSdk.Resources
         }
 
         #endregion
+
+        /// <summary>
+        /// Retrieves a list of files matching the given criteria. This operation does not support pagination.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>List of assets matching given criteria.</returns>
+        public async Task<IEnumerable<File>> SearchAsync (FileSearch query, CancellationToken token = default )
+        {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            var req = Oryx.Cognite.Files.search<IEnumerable<File>>(query);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
     }
 }
 

--- a/CogniteSdk/test/fsharp/Files.fs
+++ b/CogniteSdk/test/fsharp/Files.fs
@@ -245,29 +245,16 @@ let ``Filter Files on Source is Ok`` () = task {
     test <@ len = 10 @>
     test <@ Seq.forall ((=) "Documentum") sources @>
 }
-(*
+
 [<Trait("resource", "files")>]
 [<Fact>]
 let ``Filter Files on Name is Ok`` () = task {
     // Arrange
-    let ctx = readCtx ()
-    let options = [
-        FileQuery.Limit 10
-    ]
-    let filters = [
-        FileFilter.Name "PH-ME-P-0003-001"
-    ]
+    let query = FileQuery(Limit=Nullable 10, Filter=FileFilter(Name="PH-ME-P-0003-001"))
 
     // Act
-    let! res = Files.Items.listAsync options filters ctx
+    let! dtos = readClient.Files.ListAsync query
 
-    let ctx' =
-        match res with
-        | Ok ctx -> ctx
-        | Error (ResponseError error) -> raise <| error.ToException ()
-        | Error (Panic error) -> raise error
-
-    let dtos = ctx'.Response
     let len = Seq.length dtos.Items
 
     let names = Seq.map (fun (e: File) -> e.Name) dtos.Items
@@ -275,176 +262,107 @@ let ``Filter Files on Name is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall ((=) "PH-ME-P-0003-001") names @>
-    test <@ ctx'.Request.Method = HttpMethod.Post @>
-    test <@ ctx'.Request.Extra.["resource"] = "/files/list" @>
 }
 
 [<Trait("resource", "files")>]
 [<Fact>]
 let ``Filter Files on MimeType is Ok`` () = task {
     // Arrange
-    let ctx = readCtx ()
-    let options = [
-        FileQuery.Limit 10
-    ]
-    let filters = [
-        FileFilter.MimeType "pdf"
-    ]
+
+    let query = FileQuery(Limit=Nullable 10, Filter=FileFilter(MimeType="pdf"))
 
     // Act
-    let! res = Files.Items.listAsync options filters ctx
+    let! dtos = readClient.Files.ListAsync query
 
-    let ctx' =
-        match res with
-        | Ok ctx -> ctx
-        | Error (ResponseError error) -> raise <| error.ToException ()
-        | Error (Panic error) -> raise error
-
-    let dtos = ctx'.Response
     let len = Seq.length dtos.Items
 
-    let mimeTypes = Seq.collect (fun (e: File) -> e.MimeType |> optionToSeq) dtos.Items
+    let mimeTypes = Seq.map (fun (e: File) -> e.MimeType) dtos.Items
 
     // Assert
     test <@ len = 7 @>
     test <@ Seq.forall ((=) "pdf") mimeTypes @>
-    test <@ ctx'.Request.Method = HttpMethod.Post @>
-    test <@ ctx'.Request.Extra.["resource"] = "/files/list" @>
 }
 
 [<Trait("resource", "files")>]
 [<Fact>]
 let ``Filter Files on UploadedTime is Ok`` () = task {
     // Arrange
-    let ctx = readCtx ()
-    let options = [
-        FileQuery.Limit 10
-    ]
-    let timerange = {
-        Min = DateTimeOffset.FromUnixTimeMilliseconds(1533213278669L)
-        Max = DateTimeOffset.FromUnixTimeMilliseconds(1533213278689L)
-    }
-    let filters = [
-        FileFilter.UploadedTime timerange
-    ]
+    let timerange =
+        TimeRange(
+            Min = Nullable 1533213278669L,
+            Max = Nullable 1533213278689L
+        )
+    let query = FileQuery(Limit=Nullable 10, Filter=FileFilter(UploadedTime=timerange))
+
 
     // Act
-    let! res = Files.Items.listAsync options filters ctx
+    let! dtos = readClient.Files.ListAsync query
 
-    let ctx' =
-        match res with
-        | Ok ctx -> ctx
-        | Error (ResponseError error) -> raise <| error.ToException ()
-        | Error (Panic error) -> raise error
-
-    let dtos = ctx'.Response
     let len = Seq.length dtos.Items
 
-    let uploadedTimes = Seq.collect (fun (e: File) -> e.UploadedTime |> optionToSeq) dtos.Items
+    let uploadedTimes = Seq.map (fun (e: File) -> e.UploadedTime.Value) dtos.Items
 
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun t -> t < 1533213278689L && t > 1533213278669L) uploadedTimes @>
-    test <@ ctx'.Request.Method = HttpMethod.Post @>
-    test <@ ctx'.Request.Extra.["resource"] = "/files/list" @>
 }
 
 [<Trait("resource", "files")>]
 [<Fact>]
 let ``Filter Files on SourceCreatedTime is Ok`` () = task {
     // Arrange
-    let ctx = writeCtx ()
-    let options = [
-        FileQuery.Limit 10
-    ]
-    let timerange = {
-        Min = DateTimeOffset.FromUnixTimeMilliseconds(73125430L)
-        Max = DateTimeOffset.FromUnixTimeMilliseconds(73125450L)
-    }
-    let filters = [
-        FileFilter.SourceCreatedTime timerange
-    ]
+    let timerange =
+        TimeRange(
+            Min = Nullable 73125430L,
+            Max = Nullable 73125450L
+        )
+    let query = FileQuery(Limit=Nullable 10, Filter=FileFilter(SourceCreatedTime=timerange))
 
     // Act
-    let! res = Files.Items.listAsync options filters ctx
+    let! dtos = writeClient.Files.ListAsync query
 
-    let ctx' =
-        match res with
-        | Ok ctx -> ctx
-        | Error (ResponseError error) -> raise <| error.ToException ()
-        | Error (Panic error) -> raise error
-
-    let dtos = ctx'.Response
+    let len = Seq.length dtos.Items
     let len = Seq.length dtos.Items
 
-    let sourceCreatedTimes = Seq.collect (fun (e: File) -> e.SourceCreatedTime |> optionToSeq) dtos.Items
+    let sourceCreatedTimes = Seq.map (fun (e: File) -> e.SourceCreatedTime.Value) dtos.Items
 
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun t -> t < 73125450L && t > 73125430L) sourceCreatedTimes @>
-    test <@ ctx'.Request.Method = HttpMethod.Post @>
-    test <@ ctx'.Request.Extra.["resource"] = "/files/list" @>
 }
 
 [<Trait("resource", "files")>]
 [<Fact>]
 let ``Filter Files on SourceModifiedTime is Ok`` () = task {
     // Arrange
-    let ctx = writeCtx ()
-    let options = [
-        FileQuery.Limit 10
-    ]
-    let timerange = {
-        Min = DateTimeOffset.FromUnixTimeMilliseconds(99304940L)
-        Max = DateTimeOffset.FromUnixTimeMilliseconds(99304960L)
-    }
-    let filters = [
-        FileFilter.SourceModifiedTime timerange
-    ]
+    let timerange =
+        TimeRange(
+            Min = Nullable 99304940L,
+            Max = Nullable 99304960L
+        )
+    let query = FileQuery(Limit=Nullable 10, Filter=FileFilter(SourceModifiedTime=timerange))
 
     // Act
-    let! res = Files.Items.listAsync options filters ctx
+    let! dtos = writeClient.Files.ListAsync query
 
-    let ctx' =
-        match res with
-        | Ok ctx -> ctx
-        | Error (ResponseError error) -> raise <| error.ToException ()
-        | Error (Panic error) -> raise error
-
-    let dtos = ctx'.Response
     let len = Seq.length dtos.Items
 
-    let sourceModifiedTimes = Seq.collect (fun (e: File) -> e.SourceModifiedTime |> optionToSeq) dtos.Items
+    let sourceModifiedTimes = Seq.map (fun (e: File) -> e.SourceModifiedTime.Value) dtos.Items
 
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun t -> t < 99304960L && t > 99304940L) sourceModifiedTimes @>
-    test <@ ctx'.Request.Method = HttpMethod.Post @>
-    test <@ ctx'.Request.Extra.["resource"] = "/files/list" @>
 }
 
 [<Trait("resource", "files")>]
 [<Fact>]
 let ``Filter Files on Uploaded is Ok`` () = task {
     // Arrange
-    let ctx = readCtx ()
-    let options = [
-        FileQuery.Limit 10
-    ]
-    let filters = [
-        FileFilter.Uploaded true
-    ]
+    let query = FileQuery(Limit=Nullable 10, Filter=FileFilter(Uploaded=Nullable true))
 
     // Act
-    let! res = Files.Items.listAsync options filters ctx
+    let! dtos = readClient.Files.ListAsync query
 
-    let ctx' =
-        match res with
-        | Ok ctx -> ctx
-        | Error (ResponseError error) -> raise <| error.ToException ()
-        | Error (Panic error) -> raise error
-
-    let dtos = ctx'.Response
     let len = Seq.length dtos.Items
 
     let uploadeds = Seq.map (fun (e: File) -> e.Uploaded) dtos.Items
@@ -452,29 +370,17 @@ let ``Filter Files on Uploaded is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall id uploadeds @>
-    test <@ ctx'.Request.Method = HttpMethod.Post @>
-    test <@ ctx'.Request.Extra.["resource"] = "/files/list" @>
 }
 
 [<Trait("resource", "files")>]
 [<Fact>]
 let ``Search Files on Name is Ok`` () = task {
     // Arrange
-    let ctx = writeCtx ()
-    let searches = [
-        FileSearch.Name "test"
-    ]
+    let query = FileSearch(Search=NameSearch(Name="test"))
 
     // Act
-    let! res = Files.Search.searchAsync 10 searches [] ctx
+    let! dtos = writeClient.Files.SearchAsync query
 
-    let ctx' =
-        match res with
-        | Ok ctx -> ctx
-        | Error (ResponseError error) -> raise <| error.ToException ()
-        | Error (Panic error) -> raise error
-
-    let dtos = ctx'.Response
     let len = Seq.length dtos
 
     let names = Seq.map (fun (e: File) -> e.Name) dtos
@@ -482,62 +388,33 @@ let ``Search Files on Name is Ok`` () = task {
     // Assert
     test <@ len > 0 @>
     test <@ Seq.forall (fun (n: string) -> n.Contains "test") names @>
-    test <@ ctx'.Request.Method = HttpMethod.Post @>
-    test <@ ctx'.Request.Extra.["resource"] = "/files/search" @>
 }
 
 [<Trait("resource", "files")>]
 [<Fact>]
 let ``Create and delete files is Ok`` () = task {
     // Arrange
-    let ctx = writeCtx ()
-    let externalIdString = Guid.NewGuid().ToString()
-    let dto: Files.FileCreate = {
-        Name = "testFile"
-        ExternalId = Some externalIdString
-        MimeType = None
-        Metadata = Map.empty
-        AssetIds = Seq.empty
-        Source = None
-        SourceCreatedTime = Some 999L
-        SourceModifiedTime = Some 888L
-    }
-    let externalId = Identity.ExternalId externalIdString
+    let query = FileSearch(Search=NameSearch(Name="test"))
 
     // Act
-    let! res = Files.Create.createAsync dto ctx
-    let! delRes = Files.Delete.deleteAsync ([ externalId ]) ctx
+    let externalIdString = Guid.NewGuid().ToString()
+    let dto =
+        FileCreate(
+            Name = "testFile",
+            ExternalId = externalIdString,
+            SourceCreatedTime = Nullable 999L,
+            SourceModifiedTime = Nullable 888L
+        )
 
-    let ctx' =
-        match res with
-        | Ok ctx -> ctx
-        | Error (ResponseError error) -> raise <| error.ToException ()
-        | Error (Panic error) -> raise error
+    // Act
+    let! dto = writeClient.Files.UploadAsync dto
+    let! delRes = writeClient.Files.DeleteAsync ([ externalIdString ])
 
-    let dtos = ctx'.Response
-
-    let filesResponse = ctx'.Response
-    let resExternalId = filesResponse.ExternalId
+    let resExternalId = dto.ExternalId
 
     // Assert
-    test <@ resExternalId = Some externalIdString @>
-    test <@ ctx'.Request.Method = HttpMethod.Post @>
-    test <@ ctx'.Request.Extra.["resource"] = "/files" @>
-    test <@ ctx'.Request.Query.IsEmpty @>
-
-    let ctx'' =
-        match delRes with
-        | Ok ctx -> ctx
-        | Error (ResponseError error) -> raise <| error.ToException ()
-        | Error (Panic error) -> raise error
-
-    test <@ Result.isOk delRes @>
-    test <@ ctx''.Request.Method = HttpMethod.Post @>
-    test <@ ctx''.Request.Extra.["resource"] = "/files/delete" @>
-    test <@ ctx''.Request.Query.IsEmpty @>
+    test <@ resExternalId = externalIdString @>
 }
-
-*)
 
 [<Trait("resource", "files")>]
 [<Fact>]

--- a/CogniteSdk/test/fsharp/Login.fs
+++ b/CogniteSdk/test/fsharp/Login.fs
@@ -5,9 +5,6 @@ open Swensen.Unquote
 open Xunit
 
 open Common
-open System.Net.Http
-open CogniteSdk
-open System
 
 [<Fact>]
 let ``Login status is Ok`` () = task {

--- a/Oryx.Cognite/src/Files.fs
+++ b/Oryx.Cognite/src/Files.fs
@@ -1,13 +1,12 @@
 namespace Oryx.Cognite
 
+open System.Collections.Generic
 open System.Net.Http
 
 open Oryx
 open Oryx.Cognite
 
-open System.Collections.Generic
 open CogniteSdk
-open CogniteSdk.Files
 
 /// Various event HTTP handlers.
 
@@ -44,13 +43,12 @@ module Files =
         retrieve ids Url
         >=> logWithMessage "Files:retrieve"
 
-
-    let search (query: SearchQueryDto<FileFilter, FileSearch>) : HttpHandler<HttpResponseMessage, ItemsWithoutCursor<File>, 'a> =
-        Url +/ "search" |> postV10 query
+    let search (query: FileSearch) : HttpHandler<HttpResponseMessage, File seq, 'a> =
+        search query Url
         >=> logWithMessage "Files:search"
 
     let delete (files: ItemsWithoutCursor<Identity>) : HttpHandler<HttpResponseMessage, EmptyResponse, 'a> =
-        Url +/ "delete" |> postV10 files
+        delete files Url
         >=> logWithMessage "Files:delete"
 
     /// Update one or more assets. Supports partial updates, meaning that fields omitted from the requests are not changed. Returns list of updated assets.

--- a/Oryx.Cognite/src/Handler.fs
+++ b/Oryx.Cognite/src/Handler.fs
@@ -89,7 +89,7 @@ module Handler =
         if response.Content.Headers.ContentType.MediaType.Contains "application/json" then
             use! stream = response.Content.ReadAsStreamAsync ()
             try
-                let! error = JsonSerializer.DeserializeAsync<ApiResponseErrorDto>(stream, jsonOptions)
+                let! error = JsonSerializer.DeserializeAsync<ApiResponseError>(stream, jsonOptions)
                 let _, requestId = response.Headers.TryGetValues "x-request-id"
                 match Seq.tryExactlyOne requestId with
                 | Some requestId -> error.RequestId <- requestId

--- a/Oryx.Cognite/src/Login.fs
+++ b/Oryx.Cognite/src/Login.fs
@@ -6,7 +6,6 @@ open Oryx
 open Oryx.Cognite
 open Oryx.SystemTextJson.ResponseReader
 
-open CogniteSdk
 open CogniteSdk.Login
 
 /// Various event HTTP handlers.

--- a/Oryx.Cognite/src/Raw.fs
+++ b/Oryx.Cognite/src/Raw.fs
@@ -94,13 +94,13 @@ module Raw =
     /// </summary>
     /// <param name="database">The ids of the events to get.</param>
     /// <param name="table">The ids of the events to get.</param>
-    /// <param name="dtos">The Rows to create.</param>
+    /// <param name="rows">The Rows to create.</param>
     /// <param name="ensureParent">Default: false. Create database/table if it doesn't exist already.</param>
     /// <returns>The retrieved rows.</returns>
-    let createRows (database: string) (table: string) (dtos: RawRowCreate seq) (ensureParent: bool): HttpHandler<HttpResponseMessage, EmptyResponse, 'a> =
+    let createRows (database: string) (table: string) (rows: RawRowCreate seq) (ensureParent: bool): HttpHandler<HttpResponseMessage, EmptyResponse, 'a> =
         let query = RawRowCreateQuery(EnsureParent = ensureParent)
         Url +/ database +/ "tables" +/ table +/ "rows"
-        |> createWithQueryEmpty dtos query
+        |> createWithQueryEmpty rows query
         >=> logWithMessage "Raw:createRows"
 
     /// <summary>
@@ -108,10 +108,10 @@ module Raw =
     /// </summary>
     /// <param name="database">The ids of the events to get.</param>
     /// <param name="table">The ids of the events to get.</param>
-    /// <param name="dtos">The Rows to create.</param>
+    /// <param name="rows">The Rows to create.</param>
     /// <returns>The retrieved rows.</returns>
-    let deleteRows (database: string) (table: string) (dtos: RawRowDelete seq) : HttpHandler<HttpResponseMessage, EmptyResponse, 'a> =
-        let query = ItemsWithoutCursor<RawRowDelete>(Items=dtos)
+    let deleteRows (database: string) (table: string) (rows: RawRowDelete seq) : HttpHandler<HttpResponseMessage, EmptyResponse, 'a> =
+        let query = ItemsWithoutCursor<RawRowDelete>(Items=rows)
         Url +/ database +/ "tables" +/ table +/ "rows" +/ "delete"
         |> postV10 query
         >=> logWithMessage "Raw:deleteRows"


### PR DESCRIPTION
- Add missing File search endpoint for C# SDK
- Rename SearchQueryDto to SearchQuery to align with the rest of the types
- Re-enable file tests that had not been ported yet to the "new" SDK.