### PR TITLE
Use withTokenRenewer instead of withTokenProvider.

### DIFF
--- a/CogniteSdk/src/Resources/Resource.cs
+++ b/CogniteSdk/src/Resources/Resource.cs
@@ -48,8 +48,7 @@ namespace CogniteSdk.Resources
         /// <returns>Result.</returns>
         protected async Task<T> RunAsync<T>(Microsoft.FSharp.Core.FSharpFunc<Microsoft.FSharp.Core.FSharpFunc<Oryx.Context<T>, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>, Microsoft.FSharp.Core.FSharpFunc<HttpContext, Task<Microsoft.FSharp.Core.FSharpResult<Oryx.Context<T>, Oryx.HandlerError<ResponseException>>>>> handler, CancellationToken token)
         {
-
-            var req = _authHandler is null ? handler : withTokenProvider(_authHandler, handler);
+            var req = _authHandler is null ? handler : withTokenRenewer(_authHandler, handler);
             return await runUnsafeAsync(_ctx, token, req).ConfigureAwait(false);
         }
     }

--- a/Oryx.Cognite/src/Handler.fs
+++ b/Oryx.Cognite/src/Handler.fs
@@ -63,14 +63,21 @@ module Handler =
         | ResponseError error -> raise error
         | Panic err -> raise err
 
-    /// Use the given handler token provider for the request.
-    let withTokenProvider<'TResult, 'TNext, 'TError> (tokenProvider: Func<CancellationToken, Task<string>>) (handler: HttpHandler<HttpResponseMessage, 'TNext, 'TResult, 'TError>) =
-        let provider ct = task {
-            let! token = tokenProvider.Invoke ct
-            return Option.ofObj token
+    /// Use the given handler token provider for the request. Adapts a C# function to F#.
+    let withTokenRenewer<'TResult, 'TNext, 'TError> (tokenProvider: Func<CancellationToken, Task<string>>) (handler: HttpHandler<HttpResponseMessage, 'TNext, 'TResult, 'TError>) =
+        let renewer ct = task {
+            try
+                let! token = tokenProvider.Invoke ct
+                match Option.ofObj token with
+                | Some token ->
+                    return Ok token
+                | None ->
+                    return Panic (NullReferenceException "No token received.") |> Error
+            with
+            | ex -> return Panic ex |> Error
         }
 
-        withTokenProvider provider >=> handler
+        withTokenRenewer renewer >=> handler
 
     /// Runs handler and returns the Ok result. Throws exception if any errors occured. Used by C# SDK.
     let runUnsafeAsync (ctx : HttpContext) (token: CancellationToken) (handler: HttpHandler<HttpResponseMessage, 'r,'r>) : Task<'r> = task {

--- a/paket.lock
+++ b/paket.lock
@@ -41,18 +41,18 @@ NUGET
     Microsoft.NETCore.Platforms (3.1)
     NETStandard.Library (2.0.3)
       Microsoft.NETCore.Platforms (>= 1.1)
-    Oryx (1.0)
+    Oryx (1.1)
       FSharp.Core (>= 4.7)
       Microsoft.Extensions.Logging (>= 3.1.1)
       TaskBuilder.fs (>= 2.1)
-    Oryx.Protobuf (1.0)
+    Oryx.Protobuf (1.1)
       FSharp.Core (>= 4.7)
       Google.Protobuf (>= 3.11.3)
-      Oryx (>= 1.0)
+      Oryx (>= 1.1)
       TaskBuilder.fs (>= 2.1)
-    Oryx.SystemTextJson (1.0)
+    Oryx.SystemTextJson (1.1)
       FSharp.Core (>= 4.7)
-      Oryx (>= 1.0)
+      Oryx (>= 1.1)
       System.Text.Json (>= 4.7)
       TaskBuilder.fs (>= 2.1)
     System.Buffers (4.5)
@@ -280,18 +280,18 @@ NUGET
       System.Threading.Timer (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
       System.Xml.XDocument (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
-    Oryx (1.0)
+    Oryx (1.1)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 3.1.1) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
-    Oryx.Protobuf (1.0)
+    Oryx.Protobuf (1.1)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       Google.Protobuf (>= 3.11.3) - restriction: >= netstandard2.0
-      Oryx (>= 1.0) - restriction: >= netstandard2.0
+      Oryx (>= 1.1) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
-    Oryx.SystemTextJson (1.0)
+    Oryx.SystemTextJson (1.1)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-      Oryx (>= 1.0) - restriction: >= netstandard2.0
+      Oryx (>= 1.1) - restriction: >= netstandard2.0
       System.Text.Json (>= 4.7) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= net46) (< netstandard1.3) (>= netstandard1.6)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< netstandard1.3) (>= netstandard1.6) (>= uap10.0)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
@@ -826,7 +826,7 @@ NUGET
     Microsoft.NETCore.Platforms (3.1)
     NETStandard.Library (2.0.3)
       Microsoft.NETCore.Platforms (>= 1.1)
-    Oryx (1.0)
+    Oryx (1.1)
       FSharp.Core (>= 4.7)
       Microsoft.Extensions.Logging (>= 3.1.1)
       TaskBuilder.fs (>= 2.1)
@@ -956,18 +956,18 @@ NUGET
       System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (&& (< net20) (>= netstandard1.0) (< netstandard1.3)) (&& (< net20) (>= netstandard1.3) (< netstandard2.0))
       System.Xml.XmlDocument (>= 4.3) - restriction: && (< net20) (>= netstandard1.3) (< netstandard2.0)
     NuGet.Frameworks (5.4) - restriction: >= netcoreapp2.1
-    Oryx (1.0)
+    Oryx (1.1)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging (>= 3.1.1) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
-    Oryx.Protobuf (1.0)
+    Oryx.Protobuf (1.1)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       Google.Protobuf (>= 3.11.3) - restriction: >= netstandard2.0
-      Oryx (>= 1.0) - restriction: >= netstandard2.0
+      Oryx (>= 1.1) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
-    Oryx.SystemTextJson (1.0)
+    Oryx.SystemTextJson (1.1)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-      Oryx (>= 1.0) - restriction: >= netstandard2.0
+      Oryx (>= 1.1) - restriction: >= netstandard2.0
       System.Text.Json (>= 4.7) - restriction: >= netstandard2.0
       TaskBuilder.fs (>= 2.1) - restriction: >= netstandard2.0
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (>= netcoreapp1.0) (< netstandard1.2)) (&& (>= netcoreapp1.0) (< netstandard1.3)) (&& (>= netcoreapp1.0) (< netstandard1.4)) (&& (>= netcoreapp1.0) (< netstandard1.5)) (&& (>= netcoreapp1.0) (< netstandard1.6)) (&& (>= netcoreapp1.0) (< netstandard2.0))


### PR DESCRIPTION
This changes the semantics of the SDK to fail the request if any errors occurs while authenticating / refreshing the token which is the right thing to do. Thus we do this as a bug fix (missing error) and not as a breaking change for the SDK.