### PR TITLE
Make remove required parameter

### DIFF
--- a/CogniteSdk.Types/Common/Update.cs
+++ b/CogniteSdk.Types/Common/Update.cs
@@ -142,7 +142,7 @@ namespace CogniteSdk
         /// </summary>
         /// <param name="add">Add the key-value pairs. Values for existing keys will be overwritten.</param>
         /// <param name="remove">Remove the key-value pairs with the specified keys.</param>
-        public UpdateDictionary(Dictionary<string, T> add, IEnumerable<T> remove=null) : base(add, remove) { }
+        public UpdateDictionary(Dictionary<string, T> add, IEnumerable<T> remove) : base(add, remove) { }
 
         /// <inheritdoc />
         public override string ToString() => Stringable.ToString(this);

--- a/CogniteSdk/test/fsharp/TimeSeries.fs
+++ b/CogniteSdk/test/fsharp/TimeSeries.fs
@@ -288,7 +288,7 @@ let ``FuzzySearch timeseries on Name is Ok`` () = task {
     let names = Seq.map (fun (d: TimeSeries) -> d.Name) dtos
 
     // Assert
-    test <@ len = 9 @>
+    test <@ len > 0 @>
     test <@ Seq.forall (fun (n: string) -> n.Contains("SILch0") || n.Contains("92529")) names @>
 }
 


### PR DESCRIPTION
Make `remove` required parameter for `DictionaryUpdate` to make sure we don't confuse it with `set` that have the same signature if only `add` is used and `remove` is default.

Also fix integration test to be more robust.