### PR TITLE
Remove obsolete flags from label defs [CDF-7453]

### DIFF
--- a/CogniteSdk.Types/Assets/Asset.cs
+++ b/CogniteSdk.Types/Assets/Asset.cs
@@ -99,8 +99,8 @@ namespace CogniteSdk
 
         /// <summary>
         /// A list of labels associated with this asset
+        /// Currently only available for use in playground
         /// </summary>
-        [Obsolete("The Label attribute is in development, and currently only available for use in playground")]
         public IEnumerable<CogniteExternalId> Labels { get; set; }
 
     }

--- a/CogniteSdk.Types/Assets/Asset.cs
+++ b/CogniteSdk.Types/Assets/Asset.cs
@@ -98,8 +98,8 @@ namespace CogniteSdk
         public override string ToString() => Stringable.ToString(this);
 
         /// <summary>
-        /// A list of labels associated with this asset
-        /// Currently only available for use in playground
+        /// A list of labels associated with this asset.
+        /// Currently only available for use in playground.
         /// </summary>
         public IEnumerable<CogniteExternalId> Labels { get; set; }
 

--- a/CogniteSdk.Types/Assets/AssetCreate.cs
+++ b/CogniteSdk.Types/Assets/AssetCreate.cs
@@ -56,7 +56,7 @@ namespace CogniteSdk
 
         /// <summary>
         /// List of labels to associate with the asset.
-        /// Currently only available for use in playground
+        /// Currently only available for use in playground.
         /// </summary>
         public IEnumerable<CogniteExternalId> Labels { get; set; }
 

--- a/CogniteSdk.Types/Assets/AssetCreate.cs
+++ b/CogniteSdk.Types/Assets/AssetCreate.cs
@@ -56,8 +56,8 @@ namespace CogniteSdk
 
         /// <summary>
         /// List of labels to associate with the asset.
+        /// Currently only available for use in playground
         /// </summary>
-        [Obsolete("The Label attribute is in development, and currently only available for use in playground")]
         public IEnumerable<CogniteExternalId> Labels { get; set; }
 
         /// <inheritdoc />

--- a/CogniteSdk.Types/Assets/AssetFilter.cs
+++ b/CogniteSdk.Types/Assets/AssetFilter.cs
@@ -80,8 +80,8 @@ namespace CogniteSdk
         public override string ToString() => Stringable.ToString(this);
 
         /// <summary>
-        /// Label Filter
-        /// Currently only available for use in playground
+        /// Label Filter.
+        /// Currently only available for use in playground.
         /// </summary>
         public LabelFilter Labels { get; set; }
         //public IEnumerable<IEnumerable<CogniteExternalId>> Labels { get; set; }

--- a/CogniteSdk.Types/Assets/AssetFilter.cs
+++ b/CogniteSdk.Types/Assets/AssetFilter.cs
@@ -81,8 +81,8 @@ namespace CogniteSdk
 
         /// <summary>
         /// Label Filter
+        /// Currently only available for use in playground
         /// </summary>
-        [Obsolete("The label filter feature is in development and currently only available in playground.")]
         public LabelFilter Labels { get; set; }
         //public IEnumerable<IEnumerable<CogniteExternalId>> Labels { get; set; }
     }

--- a/CogniteSdk.Types/Assets/AssetUpdate.cs
+++ b/CogniteSdk.Types/Assets/AssetUpdate.cs
@@ -50,8 +50,8 @@ namespace CogniteSdk
         public Update<long?> ParentExternalId { get; set; }
 
         /// <summary>
-        /// Change the Labels of the object
-        /// Currently only available for use in playground
+        /// Change the Labels of the object.
+        /// Currently only available for use in playground.
         /// </summary>
         public UpdateLabels<IEnumerable<CogniteExternalId>> Labels { get; set; }
 

--- a/CogniteSdk.Types/Assets/AssetUpdate.cs
+++ b/CogniteSdk.Types/Assets/AssetUpdate.cs
@@ -51,8 +51,8 @@ namespace CogniteSdk
 
         /// <summary>
         /// Change the Labels of the object
+        /// Currently only available for use in playground
         /// </summary>
-        [System.Obsolete("The Labels attribute is in development, and currently only available for use in playground")]
         public UpdateLabels<IEnumerable<CogniteExternalId>> Labels { get; set; }
 
         /// <inheritdoc />

--- a/CogniteSdk.Types/Common/ExternalId.cs
+++ b/CogniteSdk.Types/Common/ExternalId.cs
@@ -7,24 +7,24 @@ namespace CogniteSdk
 {
     /// <summary>
     /// The CogniteExternalId read class.
-    /// Currently only available for use in playground
+    /// Currently only available for use in playground.
     /// </summary>
     public class CogniteExternalId
     {
         /// <summary>
-        /// Placeholder ExternalId Class
+        /// Placeholder ExternalId Class.
         /// </summary>
         public string ExternalId { get; set; }
 
         /// <summary>
-        /// Empty constructor method for ExternalId type
+        /// Empty constructor method for ExternalId type.
         /// </summary>
         public CogniteExternalId()
         {
         }
 
         /// <summary>
-        /// Constructor method for ExternalId type
+        /// Constructor method for ExternalId type.
         /// </summary>
         public CogniteExternalId(string externalID)
         {

--- a/CogniteSdk.Types/Common/ExternalId.cs
+++ b/CogniteSdk.Types/Common/ExternalId.cs
@@ -7,8 +7,8 @@ namespace CogniteSdk
 {
     /// <summary>
     /// The CogniteExternalId read class.
+    /// Currently only available for use in playground
     /// </summary>
-    [System.Obsolete("The ExternalId class is under development, and currently only available for use in playground")]
     public class CogniteExternalId
     {
         /// <summary>

--- a/CogniteSdk.Types/Common/LabelFilter.cs
+++ b/CogniteSdk.Types/Common/LabelFilter.cs
@@ -48,8 +48,8 @@ namespace CogniteSdk
 
     /// <summary>
     /// The Cognite Label filter class.
+    /// Currently only available for use in playground
     /// </summary>
-    [System.Obsolete("The ExternalId class is under development, and currently only available for use in playground")]
     public class LabelFilter
     {
         /// <summary>

--- a/CogniteSdk.Types/Common/LabelFilter.cs
+++ b/CogniteSdk.Types/Common/LabelFilter.cs
@@ -20,7 +20,7 @@ namespace CogniteSdk
         /// </summary>
         public LabelContainsAnyFilter(){}
         /// <summary>
-        /// Create a LabelContainsAnyFilter with the provided set of labels (CogniteExternalIds)
+        /// Create a LabelContainsAnyFilter with the provided set of labels (CogniteExternalIds).
         /// </summary>
         public LabelContainsAnyFilter(IEnumerable<CogniteExternalId> labels){
             ContainsAny = labels;
@@ -39,7 +39,7 @@ namespace CogniteSdk
         /// </summary>
         public LabelContainsAllFilter(){}
         /// <summary>
-        /// Create a LabelContainsAllFilter with the provided set of labels (CogniteExternalIds)
+        /// Create a LabelContainsAllFilter with the provided set of labels (CogniteExternalIds).
         /// </summary>
         public LabelContainsAllFilter(IEnumerable<CogniteExternalId> labels){
             ContainsAll = labels;
@@ -48,25 +48,25 @@ namespace CogniteSdk
 
     /// <summary>
     /// The Cognite Label filter class.
-    /// Currently only available for use in playground
+    /// Currently only available for use in playground.
     /// </summary>
     public class LabelFilter
     {
         /// <summary>
-        /// Filter labels that contains a single label
+        /// Filter labels that contains a single label.
         /// </summary>
         public CogniteExternalId Contains { get; set; }
         /// <summary>
-        /// Filter labels that contains any of the given labels (OR-filter)
+        /// Filter labels that contains any of the given labels (OR-filter).
         /// </summary>
         public IEnumerable<CogniteExternalId> ContainsAny { get; set; }
         /// <summary>
-        /// Filter labels that contains all of the given labels (AND-filter)
+        /// Filter labels that contains all of the given labels (AND-filter).
         /// </summary>
         public IEnumerable<CogniteExternalId> ContainsAll { get; set; }
 
         /// <summary>
-        /// LabelFilter with string parameter creates a single label filter
+        /// LabelFilter with string parameter creates a single label filter.
         /// </summary>
         public LabelFilter(string containsFilter)
         {
@@ -74,7 +74,7 @@ namespace CogniteSdk
         }
 
         /// <summary>
-        /// LabelFilter with CogniteExternalID parameter creates a single label filter
+        /// LabelFilter with CogniteExternalID parameter creates a single label filter.
         /// </summary>
         public LabelFilter(CogniteExternalId containsFilter)
         {
@@ -82,14 +82,14 @@ namespace CogniteSdk
         }
 
         /// <summary>
-        /// LabelFilter with LabelContainsAllFilter parameter creates a multilabel AND-filter
+        /// LabelFilter with LabelContainsAllFilter parameter creates a multilabel AND-filter.
         /// </summary>
         public LabelFilter(LabelContainsAllFilter labels)
         {
             ContainsAll = labels.ContainsAll;
         }
         /// <summary>
-        /// LabelFilter with LabelContainsAnyFilter parameter creates a multilabel OR-filter
+        /// LabelFilter with LabelContainsAnyFilter parameter creates a multilabel OR-filter.
         /// </summary>
         public LabelFilter(LabelContainsAnyFilter labels)
         {

--- a/CogniteSdk.Types/Common/Update.cs
+++ b/CogniteSdk.Types/Common/Update.cs
@@ -173,21 +173,21 @@ namespace CogniteSdk
 
     /// <summary>
     /// Used for adding and removing Labels, primarily for Assets.
-    /// Currently only available for use in playground
+    /// Currently only available for use in playground.
     /// </summary>
     public class UpdateLabels<TCollection>
     {
         /// <summary>
-        /// Used to add new labels
+        /// Used to add new labels.
         /// </summary>
         public TCollection Add { get; set; }
 
         /// <summary>
-        /// Used to remove labels
+        /// Used to remove labels.
         /// </summary>
         public TCollection Remove { get; set; }
         /// <summary>
-        /// Insert a Label
+        /// Insert a Label.
         /// </summary>
         public UpdateLabels(TCollection addLabels)
         {
@@ -195,9 +195,9 @@ namespace CogniteSdk
         }
 
         /// <summary>
-        /// Add and remove labels
+        /// Add and remove labels.
         /// </summary>
-        /// <param name="addLabels">Labels to Add</param>
+        /// <param name="addLabels">Labels to Add.</param>
         /// <param name="removeLabels">Labels to remove.</param>
         /// <returns></returns>
         public UpdateLabels(TCollection addLabels, TCollection removeLabels)

--- a/CogniteSdk.Types/Common/Update.cs
+++ b/CogniteSdk.Types/Common/Update.cs
@@ -173,8 +173,8 @@ namespace CogniteSdk
 
     /// <summary>
     /// Used for adding and removing Labels, primarily for Assets.
+    /// Currently only available for use in playground
     /// </summary>
-    [System.Obsolete("The UpdateLabels class is in development, and currently only available for use in playground")]
     public class UpdateLabels<TCollection>
     {
         /// <summary>
@@ -196,9 +196,8 @@ namespace CogniteSdk
 
         /// <summary>
         /// Add and remove labels
-        /// specified keys.
         /// </summary>
-        /// <param name="AddLabels">Labels to Add</param>
+        /// <param name="addLabels">Labels to Add</param>
         /// <param name="removeLabels">Labels to remove.</param>
         /// <returns></returns>
         public UpdateLabels(TCollection addLabels, TCollection removeLabels)


### PR DESCRIPTION
The obsolete flags generate compile warnings, which is more an annoyance than it is useful. Added "Currently only for use in playground" to the description of the same attributes where the obsolete flag were removed.