### PR TITLE
Optional Metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coverage.lcov
 .idea
 launchSettings.json
 .metals
+
+.fake

--- a/CogniteSdk.Types/Assets/Asset.cs
+++ b/CogniteSdk.Types/Assets/Asset.cs
@@ -8,9 +8,9 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Asset read class.
+    /// The Asset read class (without metadata).
     /// </summary>
-    public class Asset
+    public class AssetWithoutMetadata
     {
         /// <summary>
         /// External Id provided by client. Must be unique within the project.
@@ -36,12 +36,6 @@ namespace CogniteSdk
         /// Javascript friendly internal ID given to the object.
         /// </summary>
         public long? DataSetId { get; set; }
-
-        /// <summary>
-        /// Custom, application specific metadata. String key -> String value
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
-        public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
         /// The source of this asset.
@@ -101,7 +95,18 @@ namespace CogniteSdk
         /// A list of labels associated with this asset.
         /// </summary>
         public IEnumerable<CogniteExternalId> Labels { get; set; }
+    }
 
+    /// <summary>
+    /// The Asset read class (with metadata).
+    /// </summary>
+    public class Asset : AssetWithoutMetadata
+    {
+        /// <summary>
+        /// Custom, application specific metadata. String key -> String value
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }
 

--- a/CogniteSdk.Types/Assets/Asset.cs
+++ b/CogniteSdk.Types/Assets/Asset.cs
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 using System;
 using System.Collections.Generic;
-
+using System.Text.Json.Serialization;
 using CogniteSdk.Types.Common;
 
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Asset read class (without metadata).
+    /// The Asset read class (with metadata).
     /// </summary>
-    public class AssetWithoutMetadata
+    public class Asset
     {
         /// <summary>
         /// External Id provided by client. Must be unique within the project.
@@ -95,18 +95,25 @@ namespace CogniteSdk
         /// A list of labels associated with this asset.
         /// </summary>
         public IEnumerable<CogniteExternalId> Labels { get; set; }
-    }
 
-    /// <summary>
-    /// The Asset read class (with metadata).
-    /// </summary>
-    public class Asset : AssetWithoutMetadata
-    {
         /// <summary>
         /// Custom, application specific metadata. String key -> String value
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
         public Dictionary<string, string> Metadata { get; set; }
+    }
+
+    /// <summary>
+    /// The Asset read class (without metadata).
+    /// </summary>
+    public class AssetWithoutMetadata : Asset
+    {
+        /// <summary>
+        /// Custom, application specific metadata. String key -> String value
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
+        [JsonIgnore]
+        public new Dictionary<string, string> Metadata { get; set; }
     }
 }
 

--- a/CogniteSdk.Types/Common/Converters.cs
+++ b/CogniteSdk.Types/Common/Converters.cs
@@ -5,14 +5,14 @@ using System.Text.Json.Serialization;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Converts ErrorValue values from JSON to LongValue, DoubleValue or StringValue.
+    /// Converts multiple values values from JSON to LongValue, DoubleValue or StringValue.
     /// </summary>
     public class MultiValueConverter : JsonConverter<MultiValue>
     {
         /// <summary>
-        /// Produces error values from the JSON input.
+        /// Creates MultiValue values from the JSON input.
         /// </summary>
-        /// <returns>The ErrorValue. Either LongValue, DoubleValue or StringValue.</returns>
+        /// <returns>The MultiValue. Either LongValue, DoubleValue or StringValue.</returns>
         public override MultiValue Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             switch (reader.TokenType)
@@ -32,7 +32,7 @@ namespace CogniteSdk
         }
 
         /// <summary>
-        /// Not in use. We don't write any error values.
+        /// Writes MultiValue values to JSON numbers or strings.
         /// </summary>
         public override void Write(Utf8JsonWriter writer, MultiValue value, JsonSerializerOptions options)
         {
@@ -47,10 +47,10 @@ namespace CogniteSdk
                     writer.WriteStringValue(s.Value);
                     break;
                 case MultiValue.Double d:
-                    writer.WriteStringValue(d.ToString());
+                    writer.WriteNumberValue(d.Value);
                     break;
                 case MultiValue.Long l:
-                    writer.WriteStringValue(l.ToString());
+                    writer.WriteNumberValue(l.Value);
                     break;
                 default:
                     throw new ArgumentException($"Unknown MultiValue: {value}");

--- a/CogniteSdk.Types/Common/Items.cs
+++ b/CogniteSdk.Types/Common/Items.cs
@@ -8,15 +8,20 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// Holds several items. But don't support paging, i.e no cursor.
+    /// Items with a next cursor.
     /// </summary>
-    /// <typeparam name="T">A resource type.</typeparam>
+    /// <typeparam name="T">Resource type.</typeparam>
     public interface IItemsWithCursor<out T>
     {
         /// <summary>
         /// Resource items of type T.
         /// </summary>
         IEnumerable<T> Items { get; }
+
+        /// <summary>
+        /// Cursor to next page of data items.
+        /// </summary>
+        public string NextCursor { get; }
 
         /// <inheritdoc />
         string ToString();
@@ -25,8 +30,23 @@ namespace CogniteSdk
     /// <summary>
     /// Holds several items. But don't support paging, i.e no cursor.
     /// </summary>
+    /// <typeparam name="T">A resource type.</typeparam>
+    public interface IItemsWithoutCursor<out T>
+    {
+        /// <summary>
+        /// Resource items of type T.
+        /// </summary>
+        public IEnumerable<T> Items { get;  }
+
+        /// <inheritdoc />
+        public string ToString();
+    }
+
+    /// <summary>
+    /// Holds several items. But don't support paging, i.e no cursor.
+    /// </summary>
     /// <typeparam name="T">A resource type that is serializable.</typeparam>
-    public class ItemsWithoutCursor<T>
+    public class ItemsWithoutCursor<T> : IItemsWithoutCursor<T>
     {
         /// <summary>
         /// Resource items of type T.

--- a/CogniteSdk.Types/Common/Items.cs
+++ b/CogniteSdk.Types/Common/Items.cs
@@ -10,6 +10,21 @@ namespace CogniteSdk
     /// <summary>
     /// Holds several items. But don't support paging, i.e no cursor.
     /// </summary>
+    /// <typeparam name="T">A resource type.</typeparam>
+    public interface IItemsWithCursor<out T>
+    {
+        /// <summary>
+        /// Resource items of type T.
+        /// </summary>
+        IEnumerable<T> Items { get; }
+
+        /// <inheritdoc />
+        string ToString();
+    }
+
+    /// <summary>
+    /// Holds several items. But don't support paging, i.e no cursor.
+    /// </summary>
     /// <typeparam name="T">A resource type that is serializable.</typeparam>
     public class ItemsWithoutCursor<T>
     {
@@ -26,7 +41,7 @@ namespace CogniteSdk
     /// Items with a next cursor.
     /// </summary>
     /// <typeparam name="T">Resource type that is serializable.</typeparam>
-    public class ItemsWithCursor<T>
+    public class ItemsWithCursor<T> : IItemsWithCursor<T>
     {
         /// <summary>
         /// Resource items of type T.
@@ -39,7 +54,7 @@ namespace CogniteSdk
         public string NextCursor { get; set; }
 
         /// <inheritdoc />
-        public override string ToString() => Stringable.ToString<ItemsWithCursor<T>>(this);
+        public override string ToString() => Stringable.ToString(this);
     }
 
     /// <summary>

--- a/CogniteSdk.Types/Events/Event.cs
+++ b/CogniteSdk.Types/Events/Event.cs
@@ -8,10 +8,9 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Event read class.
+    /// The Event read class (without metadata).
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Warning", "CA1716: Identifiers should not match keywords", Justification = "We also have events")]
-    public class Event
+    public class EventWithoutMetadata
     {
         /// <summary>
         /// External Id provided by client. Must be unique within the project.
@@ -48,13 +47,6 @@ namespace CogniteSdk
         /// </summary>
         public string Description { get; set; }
 
-
-        /// <summary>
-        /// Custom, application specific metadata. String key -> String value
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
-        public Dictionary<string, string> Metadata { get; set; }
-
         /// <summary>
         /// Asset IDs of related equipment that this event relates to.
         /// </summary>
@@ -86,7 +78,7 @@ namespace CogniteSdk
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
         public override bool Equals(object obj)
         {
-            return obj is Event dto && Id == dto.Id;
+            return obj is EventWithoutMetadata dto && Id == dto.Id;
         }
 
         /// <summary>Serves as the default hash function.</summary>
@@ -98,6 +90,19 @@ namespace CogniteSdk
 
         /// <inheritdoc />
         public override string ToString() => Stringable.ToString(this);
+    }
+
+    /// <summary>
+    /// The Event read class.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Warning", "CA1716: Identifiers should not match keywords", Justification = "We also have events")]
+    public class Event : EventWithoutMetadata
+    {
+        /// <summary>
+        /// Custom, application specific metadata. String key -> String value
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }
 

--- a/CogniteSdk.Types/Events/Event.cs
+++ b/CogniteSdk.Types/Events/Event.cs
@@ -84,7 +84,7 @@ namespace CogniteSdk
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
         public override bool Equals(object obj)
         {
-            return obj is EventWithoutMetadata dto && Id == dto.Id;
+            return obj is Event dto && Id == dto.Id;
         }
 
         /// <summary>Serves as the default hash function.</summary>

--- a/CogniteSdk.Types/Events/Event.cs
+++ b/CogniteSdk.Types/Events/Event.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// The Event read class (without metadata).
+    /// The Event read class (with metadata).
     /// </summary>
     public class Event
     {
@@ -99,7 +99,7 @@ namespace CogniteSdk
     }
 
     /// <summary>
-    /// The Event read class.
+    /// The Event read class (without meta-data).
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Warning", "CA1716: Identifiers should not match keywords", Justification = "We also have events")]
     public class EventWithoutMetadata : Event

--- a/CogniteSdk.Types/Events/Event.cs
+++ b/CogniteSdk.Types/Events/Event.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
-
+using System.Text.Json.Serialization;
 using CogniteSdk.Types.Common;
 
 namespace CogniteSdk
@@ -10,7 +10,7 @@ namespace CogniteSdk
     /// <summary>
     /// The Event read class (without metadata).
     /// </summary>
-    public class EventWithoutMetadata
+    public class Event
     {
         /// <summary>
         /// External Id provided by client. Must be unique within the project.
@@ -73,6 +73,12 @@ namespace CogniteSdk
         /// <value></value>
         public long LastUpdatedTime { get; set; }
 
+        /// <summary>
+        /// Custom, application specific metadata. String key -> String value
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
+        public Dictionary<string, string> Metadata { get; set; }
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -96,13 +102,14 @@ namespace CogniteSdk
     /// The Event read class.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Warning", "CA1716: Identifiers should not match keywords", Justification = "We also have events")]
-    public class Event : EventWithoutMetadata
+    public class EventWithoutMetadata : Event
     {
         /// <summary>
         /// Custom, application specific metadata. String key -> String value
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
-        public Dictionary<string, string> Metadata { get; set; }
+        [JsonIgnore]
+        public new Dictionary<string, string> Metadata { get; set; }
     }
 }
 

--- a/CogniteSdk.Types/Timeseries/TimeSeries.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeries.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using CogniteSdk.Types.Common;
 
 namespace CogniteSdk
@@ -9,7 +10,7 @@ namespace CogniteSdk
     /// <summary>
     /// TimeSeries read class (without metadata).
     /// </summary>
-    public class TimeSeriesWithoutMetadata
+    public class TimeSeries
     {
         /// <summary>
         /// Server-generated ID for the object
@@ -73,6 +74,13 @@ namespace CogniteSdk
         /// </summary>
         public long LastUpdatedTime { get; set; }
 
+        /// <summary>
+        /// Custom, application specific metadata. Maximum length of key is 32 bytes, value 512 bytes, up to 16
+        /// key-value pairs.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
+        public Dictionary<string, string> Metadata { get; set; }
+
         /// <inheritdoc />
         public override string ToString() => Stringable.ToString(this);
     }
@@ -80,13 +88,14 @@ namespace CogniteSdk
     /// <summary>
     /// TimeSeries read class.
     /// </summary>
-    public class TimeSeries : TimeSeriesWithoutMetadata
+    public class TimeSeriesWithoutMetadata : TimeSeries
     {
         /// <summary>
         /// Custom, application specific metadata. Maximum length of key is 32 bytes, value 512 bytes, up to 16
         /// key-value pairs.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
-        public Dictionary<string, string> Metadata { get; set; }
+        [JsonIgnore]
+        public new Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/CogniteSdk.Types/Timeseries/TimeSeries.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeries.cs
@@ -8,7 +8,7 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// TimeSeries read class (without metadata).
+    /// TimeSeries read class.
     /// </summary>
     public class TimeSeries
     {
@@ -86,7 +86,7 @@ namespace CogniteSdk
     }
 
     /// <summary>
-    /// TimeSeries read class.
+    /// TimeSeries read class (without metadata).
     /// </summary>
     public class TimeSeriesWithoutMetadata : TimeSeries
     {

--- a/CogniteSdk.Types/Timeseries/TimeSeries.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeries.cs
@@ -7,9 +7,9 @@ using CogniteSdk.Types.Common;
 namespace CogniteSdk
 {
     /// <summary>
-    /// TimeSeries read class.
+    /// TimeSeries read class (without metadata).
     /// </summary>
-    public class TimeSeries
+    public class TimeSeriesWithoutMetadata
     {
         /// <summary>
         /// Server-generated ID for the object
@@ -35,13 +35,6 @@ namespace CogniteSdk
         /// Whether the time series is string valued or not.
         /// </summary>
         public bool IsString { get; set; }
-
-        /// <summary>
-        /// Custom, application specific metadata. Maximum length of key is 32 bytes, value 512 bytes, up to 16
-        /// key-value pairs.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
-        public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
         /// The physical unit of the time series.
@@ -82,5 +75,18 @@ namespace CogniteSdk
 
         /// <inheritdoc />
         public override string ToString() => Stringable.ToString(this);
+    }
+
+    /// <summary>
+    /// TimeSeries read class.
+    /// </summary>
+    public class TimeSeries : TimeSeriesWithoutMetadata
+    {
+        /// <summary>
+        /// Custom, application specific metadata. Maximum length of key is 32 bytes, value 512 bytes, up to 16
+        /// key-value pairs.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "System.Text.Json ignores properties that don't have setters")]
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -331,7 +331,7 @@ namespace CogniteSdk
                 // Builder is invalid after this
                 _context = null;
                 _authHandler = null;
-                _includeMetadata = false;
+                _includeMetadata = true;
                 return new Client(authHandler, includeMetadata, ctx);
             }
 

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -90,15 +90,14 @@ namespace CogniteSdk
         /// Client for making requests to the API.
         /// </summary>
         /// <param name="authHandler">The authentication handler.</param>
-        /// <param name="includeMetadata">Include meta-data in responses or not.</param>
         /// <param name="ctx">Context to use for this session.</param>
-        private Client(Func<CancellationToken, Task<string>> authHandler, bool includeMetadata, HttpContext ctx)
+        private Client(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx)
         {
             // Setup resources.
-            Assets = new AssetsResource(authHandler, includeMetadata, ctx);
-            TimeSeries = new TimeSeriesResource(authHandler, includeMetadata, ctx);
+            Assets = new AssetsResource(authHandler, ctx);
+            TimeSeries = new TimeSeriesResource(authHandler, ctx);
             DataPoints = new DataPointsResource(authHandler, ctx);
-            Events = new EventsResource(authHandler, includeMetadata, ctx);
+            Events = new EventsResource(authHandler, ctx);
             Sequences = new SequencesResource(authHandler, ctx);
             Raw = new RawResource(authHandler, ctx);
             ThreeDModels = new ThreeDModelsResource(authHandler, ctx);
@@ -119,7 +118,6 @@ namespace CogniteSdk
         {
             private HttpContext _context = create();
             private Func<CancellationToken, Task<string>> _authHandler;
-            private bool _includeMetadata = true;
 
             /// <summary>
             /// Create Client builder.
@@ -307,17 +305,6 @@ namespace CogniteSdk
             }
 
             /// <summary>
-            /// Include or exclude metadata decoding.
-            /// </summary>
-            /// <param name="includeMetadata">True if metadata should be included. Set to false to disable meta-data decoding.</param>
-            /// <returns>Updated builder.</returns>
-            public Builder IncludeMetadata(bool includeMetadata)
-            {
-                _includeMetadata = includeMetadata;
-                return this;
-            }
-
-            /// <summary>
             /// Builds the new client. Builder is invalid after this.
             /// </summary>
             /// <returns>New client.</returns>
@@ -326,13 +313,11 @@ namespace CogniteSdk
                 // Check for optional fields etc here
                 HttpContext ctx = _context;
                 Func<CancellationToken, Task<string>> authHandler = _authHandler;
-                bool includeMetadata = _includeMetadata;
 
                 // Builder is invalid after this
                 _context = null;
                 _authHandler = null;
-                _includeMetadata = true;
-                return new Client(authHandler, includeMetadata, ctx);
+                return new Client(authHandler, ctx);
             }
 
             /// <summary>

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -119,7 +119,7 @@ namespace CogniteSdk
         {
             private HttpContext _context = create();
             private Func<CancellationToken, Task<string>> _authHandler;
-            private bool _includeMetadata = false;
+            private bool _includeMetadata = true;
 
             /// <summary>
             /// Create Client builder.

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -89,7 +89,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously retrieve information about an asset given an asset id.
+        /// Asynchronously retrieve information about an asset like object given an asset id.
         /// </summary>
         /// <param name="assetId">The id of the asset to get.</param>
         /// <param name="token">Optional cancellation token.</param>

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -51,30 +51,7 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given filters and optional cursor</returns>
         public async Task<ItemsWithCursor<Asset>> ListAsync(AssetQuery query, CancellationToken token = default)
         {
-            var ret = await ListAsync<Asset>(query, token);
-            return ret as ItemsWithCursor<Asset>;
-        }
-
-        /// <summary>
-        /// Retrieve list of asset like objects matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>List of assets matching given filters and optional cursor</returns>
-        public IItemsWithCursor<T> List<T>(AssetQuery query, CancellationToken token = default) where T : Asset
-        {
-            return ListAsync<T>(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieve list of assets matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>List of assets matching given filters and optional cursor</returns>
-        public ItemsWithCursor<Asset> List(AssetQuery query, CancellationToken token = default)
-        {
-            return (ItemsWithCursor<Asset>) ListAsync<Asset>(query, token).GetAwaiter().GetResult();
+            return (ItemsWithCursor<Asset>) await ListAsync<Asset>(query, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -95,17 +72,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieve the number of assets matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>Number of assets matching given filters and optional cursor</returns>
-        public int Aggregate(AssetQuery query, CancellationToken token = default)
-        {
-            return AggregateAsync(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously create assets.
         /// </summary>
         /// <param name="assets">Assets to create.</param>
@@ -120,17 +86,6 @@ namespace CogniteSdk.Resources
 
             var req = Assets.create<IEnumerable<Asset>>(assets);
             return await RunAsync(req, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Create assets.
-        /// </summary>
-        /// <param name="assets">Assets to create.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>Sequence of created assets.</returns>
-        public IEnumerable<Asset> Create(IEnumerable<AssetCreate> assets, CancellationToken token = default)
-        {
-            return CreateAsync(assets, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -153,29 +108,7 @@ namespace CogniteSdk.Resources
         /// <returns>Asset with the given id.</returns>
         public async Task<Asset> GetAsync(long assetId, CancellationToken token = default)
         {
-            return await GetAsync<Asset>(assetId, token);
-        }
-
-        /// <summary>
-        /// Retrieves information about an asset like object given an asset id.
-        /// </summary>
-        /// <param name="assetId">The id of the asset to get.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>Asset with the given id.</returns>
-        public T Get<T>(long assetId, CancellationToken token = default) where T : Asset
-        {
-            return GetAsync<T>(assetId, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieves information about an asset like object given an asset id.
-        /// </summary>
-        /// <param name="assetId">The id of the asset to get.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>Asset with the given id.</returns>
-        public Asset Get(long assetId, CancellationToken token = default)
-        {
-            return GetAsync<Asset>(assetId, token).GetAwaiter().GetResult();
+            return await GetAsync<Asset>(assetId, token).ConfigureAwait(false);
         }
 
         #region Delete overloads
@@ -197,17 +130,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple assets in the same project, along with all their descendants in the asset hierarchy if
-        /// recursive is true.
-        /// </summary>
-        /// <param name="query">The query of assets to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(AssetDelete query, CancellationToken token = default)
-        {
-            return DeleteAsync(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously delete multiple assets in the same project by identity items.
         /// </summary>
         /// <param name="items">The list of assets identities to delete.</param>
@@ -221,16 +143,6 @@ namespace CogniteSdk.Resources
 
             var query = new AssetDelete() { Items = items };
             return await DeleteAsync(query, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Delete multiple assets in the same project by identity items.
-        /// </summary>
-        /// <param name="items">The list of assets identities to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(IEnumerable<Identity> items, CancellationToken token = default)
-        {
-            return DeleteAsync(items, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -250,16 +162,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple assets in the same project by internal ids.
-        /// </summary>
-        /// <param name="internalIds">The list of assets ids to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(IEnumerable<long> internalIds, CancellationToken token = default)
-        {
-            return DeleteAsync(internalIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously delete multiple assets in the same project by external ids.
         /// </summary>
         /// <param name="externalIds">The list of assets ids to delete.</param>
@@ -273,16 +175,6 @@ namespace CogniteSdk.Resources
 
             var query = new AssetDelete() { Items = externalIds.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Delete multiple assets in the same project by external ids.
-        /// </summary>
-        /// <param name="externalIds">The list of assets ids to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(IEnumerable<string> externalIds, CancellationToken token = default)
-        {
-            return DeleteAsync(externalIds, token).GetAwaiter().GetResult();
         }
         #endregion
 
@@ -314,31 +206,7 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Asset>> RetrieveAsync(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
-            return await RetrieveAsync<Asset>(ids, ignoreUnknownIds, token);
-        }
-
-        /// <summary>
-        /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs
-        /// may be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="ids">The list of assets identities to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<T> Retrieve<T>(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : Asset
-        {
-            return RetrieveAsync<T>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieves information about multiple asset like objects in the same project. A maximum of 1000 assets IDs
-        /// may be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="ids">The list of assets identities to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<Asset> Retrieve(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
-        {
-            return RetrieveAsync<Asset>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
+            return await RetrieveAsync<Asset>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -360,32 +228,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple asset like objects in the same project. A maximum of 1000 assets IDs
-        /// may be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="internalIds">The list of assets internal identities to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<T> Retrieve<T>(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : Asset
-        {
-            var ids = internalIds.Select(Identity.Create);
-            return RetrieveAsync<T>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs may be listed
-        /// per request and all of them must be unique.
-        /// </summary>
-        /// <param name="internalIds">The list of assets internal identities to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<Asset> Retrieve(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
-        {
-            var ids = internalIds.Select(Identity.Create);
-            return RetrieveAsync<Asset>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs
         /// may be listed per request and all of them must be unique.
         /// </summary>
@@ -403,31 +245,6 @@ namespace CogniteSdk.Resources
             return await RetrieveAsync<Asset>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Retrieves information about multiple asset like objects in the same project. A maximum of 1000 assets IDs
-        /// may be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="externalIds">The list of assets internal identities to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<T> Retrieve<T>(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : Asset
-        {
-            var ids = externalIds.Select(Identity.Create);
-            return RetrieveAsync<T>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs may be listed
-        /// per request and all of them must be unique.
-        /// </summary>
-        /// <param name="externalIds">The list of assets internal identities to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<Asset> Retrieve(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
-        {
-            var ids = externalIds.Select(Identity.Create);
-            return RetrieveAsync<Asset>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
         #endregion
 
         /// <summary>
@@ -457,29 +274,7 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given criteria.</returns>
         public async Task<IEnumerable<Asset>> SearchAsync(AssetSearch query, CancellationToken token = default)
         {
-            return await SearchAsync<Asset>(query, token);
-        }
-
-        /// <summary>
-        /// Retrieve a list of asset like objects matching the given criteria. This operation does not support pagination.
-        /// </summary>
-        /// <param name="query">Search query.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of assets matching given criteria.</returns>
-        public IEnumerable<T> Search<T>(AssetSearch query, CancellationToken token = default) where T : Asset
-        {
-            return SearchAsync<T>(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieve a list of assets matching the given criteria. This operation does not support pagination.
-        /// </summary>
-        /// <param name="query">Search query.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of assets matching given criteria.</returns>
-        public IEnumerable<Asset> Search(AssetSearch query, CancellationToken token = default)
-        {
-            return SearchAsync<Asset>(query, token).GetAwaiter().GetResult();
+            return await SearchAsync<Asset>(query, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -498,18 +293,6 @@ namespace CogniteSdk.Resources
 
             var req = Assets.update<Asset, IEnumerable<Asset>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Update one or more assets. Supports partial updates, meaning that fields omitted from the requests are not
-        /// changed
-        /// </summary>
-        /// <param name="query">The list of assets to update.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of updated assets.</returns>
-        public IEnumerable<Asset> Update(IEnumerable<AssetUpdateItem> query, CancellationToken token = default)
-        {
-            return UpdateAsync(query, token).GetAwaiter().GetResult();
         }
     }
 }

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -22,8 +22,9 @@ namespace CogniteSdk.Resources
         /// Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">Authentication handler.</param>
+        /// <param name="includeMetadata">Include meta-data in responses or not.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal AssetsResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
+        internal AssetsResource(Func<CancellationToken, Task<string>> authHandler, bool includeMetadata, HttpContext ctx) : base(authHandler, includeMetadata, ctx)
         {
         }
 
@@ -33,15 +34,20 @@ namespace CogniteSdk.Resources
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>List of assets matching given filters and optional cursor</returns>
-        public async Task<ItemsWithCursor<Asset>> ListAsync(AssetQuery query, CancellationToken token = default)
+        public async Task<IItemsWithCursor<Asset>> ListAsync(AssetQuery query, CancellationToken token = default)
         {
             if (query is null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Assets.list<Asset, ItemsWithCursor<Asset>>(query);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata) {
+                var req = Assets.list<Asset, ItemsWithCursor<Asset>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            } else {
+                var req = Assets.list<AssetWithoutMetadata, ItemsWithCursor<AssetWithoutMetadata>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -50,7 +56,7 @@ namespace CogniteSdk.Resources
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>List of assets matching given filters and optional cursor</returns>
-        public ItemsWithCursor<Asset> List(AssetQuery query, CancellationToken token = default)
+        public IItemsWithCursor<Asset> List(AssetQuery query, CancellationToken token = default)
         {
             return ListAsync(query, token).GetAwaiter().GetResult();
         }
@@ -119,8 +125,13 @@ namespace CogniteSdk.Resources
         /// <returns>Asset with the given id.</returns>
         public async Task<Asset> GetAsync(long assetId, CancellationToken token = default)
         {
-            var req = Assets.get<Asset, Asset>(assetId);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata) {
+                var req = Assets.get<Asset, Asset>(assetId);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            } else {
+                var req = Assets.get<AssetWithoutMetadata, AssetWithoutMetadata>(assetId);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -41,10 +41,13 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            if (_includeMetadata) {
+            if (_includeMetadata)
+            {
                 var req = Assets.list<Asset, ItemsWithCursor<Asset>>(query);
                 return await RunAsync(req, token).ConfigureAwait(false);
-            } else {
+            }
+            else
+            {
                 var req = Assets.list<AssetWithoutMetadata, ItemsWithCursor<AssetWithoutMetadata>>(query);
                 return await RunAsync(req, token).ConfigureAwait(false);
             }
@@ -125,10 +128,13 @@ namespace CogniteSdk.Resources
         /// <returns>Asset with the given id.</returns>
         public async Task<Asset> GetAsync(long assetId, CancellationToken token = default)
         {
-            if (_includeMetadata) {
+            if (_includeMetadata)
+            {
                 var req = Assets.get<Asset, Asset>(assetId);
                 return await RunAsync(req, token).ConfigureAwait(false);
-            } else {
+            }
+            else
+            {
                 var req = Assets.get<AssetWithoutMetadata, AssetWithoutMetadata>(assetId);
                 return await RunAsync(req, token).ConfigureAwait(false);
             }

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -274,8 +274,16 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(ids));
             }
 
-            var req = Assets.retrieve<Asset, IEnumerable<Asset>>(ids, ignoreUnknownIds);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata)
+            {
+                var req = Assets.retrieve<Asset, IEnumerable<Asset>>(ids, ignoreUnknownIds);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
+            else
+            {
+                var req = Assets.retrieve<AssetWithoutMetadata, IEnumerable<AssetWithoutMetadata>>(ids, ignoreUnknownIds);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -364,8 +372,16 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Assets.search<Asset, IEnumerable<Asset>>(query);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata)
+            {
+                var req = Assets.search<Asset, IEnumerable<Asset>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
+            else
+            {
+                var req = Assets.search<AssetWithoutMetadata, IEnumerable<AssetWithoutMetadata>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -31,6 +31,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
+        /// <typeparam name="T">Type of asset to return, e.g Assset or AssetWithoutMetadata.</typeparam>
         /// <returns>List of assets matching given filters and optional cursor</returns>
         public async Task<IItemsWithCursor<T>> ListAsync<T>(AssetQuery query, CancellationToken token = default) where T : Asset
         {
@@ -93,6 +94,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="assetId">The id of the asset to get.</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <typeparam name="T">Type of asset to return, e.g Assset or AssetWithoutMetadata.</typeparam>
         /// <returns>Asset with the given id.</returns>
         public async Task<T> GetAsync<T>(long assetId, CancellationToken token = default) where T : Asset
         {
@@ -185,7 +187,9 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="ids">The list of assets identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <typeparam name="T">Type of asset to return, e.g Assset or AssetWithoutMetadata.</typeparam>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested assets.</returns>
         public async Task<IEnumerable<T>> RetrieveAsync<T>(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : Asset
         {
             if (ids is null)
@@ -204,6 +208,7 @@ namespace CogniteSdk.Resources
         /// <param name="ids">The list of assets identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested assets.</returns>
         public async Task<IEnumerable<Asset>> RetrieveAsync(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             return await RetrieveAsync<Asset>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
@@ -216,6 +221,7 @@ namespace CogniteSdk.Resources
         /// <param name="internalIds">The list of assets internal identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested assets.</returns>
         public async Task<IEnumerable<Asset>> RetrieveAsync(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             if (internalIds is null)
@@ -234,6 +240,7 @@ namespace CogniteSdk.Resources
         /// <param name="externalIds">The list of assets internal identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested assets.</returns>
         public async Task<IEnumerable<Asset>> RetrieveAsync(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             if (externalIds is null)
@@ -253,7 +260,8 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of assets matching given criteria.</returns>
+        /// <typeparam name="T">Type of asset to return, e.g Assset or AssetWithoutMetadata.</typeparam>
+        /// <returns>Sequence of assets matching given criteria.</returns>
         public async Task<IEnumerable<T>> SearchAsync<T>(AssetSearch query, CancellationToken token = default) where T : Asset
         {
             if (query is null)
@@ -271,7 +279,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of assets matching given criteria.</returns>
+        /// <returns>Sequence of assets matching given criteria.</returns>
         public async Task<IEnumerable<Asset>> SearchAsync(AssetSearch query, CancellationToken token = default)
         {
             return await SearchAsync<Asset>(query, token).ConfigureAwait(false);
@@ -283,7 +291,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">The list of assets to update.</param>
         /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of updated assets.</returns>
+        /// <returns>Sequence of updated assets.</returns>
         public async Task<IEnumerable<Asset>> UpdateAsync(IEnumerable<AssetUpdateItem> query, CancellationToken token = default)
         {
             if (query is null)

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -40,7 +40,35 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Assets.list<ItemsWithCursor<Asset>>(query);
+            var req = Assets.list<Asset, ItemsWithCursor<Asset>>(query);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves list of assets matching query.
+        /// </summary>
+        /// <param name="query">The query filter to use.</param>
+        /// <param name="token">Optional cancellation token to use.</param>
+        /// <returns>List of assets matching given filters and optional cursor</returns>
+        public ItemsWithCursor<Asset> List(AssetQuery query, CancellationToken token = default)
+        {
+            return ListAsync(query, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Retrieves number of assets matching query.
+        /// </summary>
+        /// <param name="query">The query filter to use.</param>
+        /// <param name="token">Optional cancellation token to use.</param>
+        /// <returns>Number of assets matching given filters and optional cursor</returns>
+        public async Task<int> AggregateAsync(AssetQuery query, CancellationToken token = default)
+        {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            var req = Assets.aggregate<int>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
@@ -50,15 +78,9 @@ namespace CogniteSdk.Resources
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>Number of assets matching given filters and optional cursor</returns>
-        public async Task<Int32> AggregateAsync(AssetQuery query, CancellationToken token = default)
+        public int Aggregate(AssetQuery query, CancellationToken token = default)
         {
-            if (query is null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-
-            var req = Assets.aggregate<Int32>(query);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            return AggregateAsync(query, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -79,6 +101,17 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
+        /// Create assets.
+        /// </summary>
+        /// <param name="assets">Assets to create.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>Sequence of created assets.</returns>
+        public IEnumerable<Asset> Create(IEnumerable<AssetCreate> assets, CancellationToken token = default)
+        {
+            return CreateAsync(assets, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Retrieves information about an asset given an asset id.
         /// </summary>
         /// <param name="assetId">The id of the asset to get.</param>
@@ -86,8 +119,19 @@ namespace CogniteSdk.Resources
         /// <returns>Asset with the given id.</returns>
         public async Task<Asset> GetAsync(long assetId, CancellationToken token = default)
         {
-            var req = Assets.get<Asset>(assetId);
+            var req = Assets.get<Asset, Asset>(assetId);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves information about an asset given an asset id.
+        /// </summary>
+        /// <param name="assetId">The id of the asset to get.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>Asset with the given id.</returns>
+        public Asset Get(long assetId, CancellationToken token = default)
+        {
+            return GetAsync(assetId, token).GetAwaiter().GetResult();
         }
 
         #region Delete overloads
@@ -109,6 +153,17 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
+        /// Delete multiple assets in the same project, along with all their descendants in the asset hierarchy if
+        /// recursive is true.
+        /// </summary>
+        /// <param name="query">The query of assets to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(AssetDelete query, CancellationToken token = default)
+        {
+            return DeleteAsync(query, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Delete multiple assets in the same project by identity items.
         /// </summary>
         /// <param name="items">The list of assets identities to delete.</param>
@@ -122,6 +177,16 @@ namespace CogniteSdk.Resources
 
             var query = new AssetDelete() { Items = items };
             return await DeleteAsync(query, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Delete multiple assets in the same project by identity items.
+        /// </summary>
+        /// <param name="items">The list of assets identities to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(IEnumerable<Identity> items, CancellationToken token = default)
+        {
+            return DeleteAsync(items, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -141,6 +206,16 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
+        /// Delete multiple assets in the same project by internal ids.
+        /// </summary>
+        /// <param name="internalIds">The list of assets ids to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(IEnumerable<long> internalIds, CancellationToken token = default)
+        {
+            return DeleteAsync(internalIds, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Delete multiple assets in the same project by external ids.
         /// </summary>
         /// <param name="externalIds">The list of assets ids to delete.</param>
@@ -154,6 +229,16 @@ namespace CogniteSdk.Resources
 
             var query = new AssetDelete() { Items = externalIds.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Delete multiple assets in the same project by external ids.
+        /// </summary>
+        /// <param name="externalIds">The list of assets ids to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(IEnumerable<string> externalIds, CancellationToken token = default)
+        {
+            return DeleteAsync(externalIds, token).GetAwaiter().GetResult();
         }
         #endregion
 
@@ -172,8 +257,20 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(ids));
             }
 
-            var req = Assets.retrieve<IEnumerable<Asset>>(ids, ignoreUnknownIds);
+            var req = Assets.retrieve<Asset, IEnumerable<Asset>>(ids, ignoreUnknownIds);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs may be listed
+        /// per request and all of them must be unique.
+        /// </summary>
+        /// <param name="ids">The list of assets identities to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public IEnumerable<Asset> Retrieve(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return RetrieveAsync(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -198,6 +295,18 @@ namespace CogniteSdk.Resources
         /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs may be listed
         /// per request and all of them must be unique.
         /// </summary>
+        /// <param name="internalIds">The list of assets internal identities to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public IEnumerable<Asset> Retrieve(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return RetrieveAsync(internalIds, ignoreUnknownIds, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs may be listed
+        /// per request and all of them must be unique.
+        /// </summary>
         /// <param name="externalIds">The list of assets internal identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -211,6 +320,18 @@ namespace CogniteSdk.Resources
             var ids = externalIds.Select(Identity.Create);
             return await RetrieveAsync(ids, ignoreUnknownIds, token).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs may be listed
+        /// per request and all of them must be unique.
+        /// </summary>
+        /// <param name="externalIds">The list of assets internal identities to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public IEnumerable<Asset> Retrieve(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return RetrieveAsync(externalIds, ignoreUnknownIds, token).GetAwaiter().GetResult();
+        }
         #endregion
 
         /// <summary>
@@ -219,14 +340,43 @@ namespace CogniteSdk.Resources
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
         /// <returns>List of assets matching given criteria.</returns>
-        public async Task<IEnumerable<Asset>> SearchAsync (AssetSearch query, CancellationToken token = default )
+        public async Task<IEnumerable<Asset>> SearchAsync(AssetSearch query, CancellationToken token = default )
         {
             if (query is null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Assets.search<IEnumerable<Asset>>(query);
+            var req = Assets.search<Asset, IEnumerable<Asset>>(query);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves a list of assets matching the given criteria. This operation does not support pagination.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>List of assets matching given criteria.</returns>
+        public IEnumerable<Asset> Search(AssetSearch query, CancellationToken token = default)
+        {
+            return SearchAsync(query, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Update one or more assets. Supports partial updates, meaning that fields omitted from the requests are not
+        /// changed
+        /// </summary>
+        /// <param name="query">The list of assets to update.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>List of updated assets.</returns>
+        public async Task<IEnumerable<Asset>> UpdateAsync(IEnumerable<AssetUpdateItem> query, CancellationToken token = default)
+        {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            var req = Assets.update<Asset, IEnumerable<Asset>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
@@ -237,15 +387,9 @@ namespace CogniteSdk.Resources
         /// <param name="query">The list of assets to update.</param>
         /// <param name="token">Optional cancellation token.</param>
         /// <returns>List of updated assets.</returns>
-        public async Task<IEnumerable<Asset>> UpdateAsync (IEnumerable<AssetUpdateItem> query, CancellationToken token = default )
+        public IEnumerable<Asset> Update(IEnumerable<AssetUpdateItem> query, CancellationToken token = default)
         {
-            if (query is null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-
-            var req = Assets.update<IEnumerable<Asset>>(query);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            return UpdateAsync(query, token).GetAwaiter().GetResult();
         }
     }
 }

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -19,7 +19,7 @@ namespace CogniteSdk.Resources
     public class AssetsResource : Resource
     {
         /// <summary>
-        /// Will only be instantiated by the client.
+        /// The class constructor. Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">Authentication handler.</param>
         /// <param name="includeMetadata">Include meta-data in responses or not.</param>
@@ -29,7 +29,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves list of assets matching query.
+        /// Asynchronously retrieves list of assets matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -54,7 +54,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves list of assets matching query.
+        /// Retrieve list of assets matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -65,7 +65,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves number of assets matching query.
+        /// Asynchronously retrieve number of assets matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -82,7 +82,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves number of assets matching query.
+        /// Retrieve the number of assets matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -93,7 +93,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Create assets.
+        /// Asynchronously create assets.
         /// </summary>
         /// <param name="assets">Assets to create.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -121,7 +121,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about an asset given an asset id.
+        /// Asynchronously retrieve information about an asset given an asset id.
         /// </summary>
         /// <param name="assetId">The id of the asset to get.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -153,8 +153,8 @@ namespace CogniteSdk.Resources
 
         #region Delete overloads
         /// <summary>
-        /// Delete multiple assets in the same project, along with all their descendants in the asset hierarchy if
-        /// recursive is true.
+        /// Asynchronously delete multiple assets in the same project, along with all their descendants in the asset
+        /// hierarchy if recursive is true.
         /// </summary>
         /// <param name="query">The query of assets to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -181,7 +181,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple assets in the same project by identity items.
+        /// Asynchronously delete multiple assets in the same project by identity items.
         /// </summary>
         /// <param name="items">The list of assets identities to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -207,7 +207,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple assets in the same project by internal ids.
+        /// Asynchronously delete multiple assets in the same project by internal ids.
         /// </summary>
         /// <param name="internalIds">The list of assets ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -233,7 +233,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple assets in the same project by external ids.
+        /// Asynchronously delete multiple assets in the same project by external ids.
         /// </summary>
         /// <param name="externalIds">The list of assets ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -261,8 +261,8 @@ namespace CogniteSdk.Resources
 
         #region Retrieve overloads
         /// <summary>
-        /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs may be listed
-        /// per request and all of them must be unique.
+        /// Asynchronously retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs
+        /// may be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="ids">The list of assets identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
@@ -299,8 +299,8 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs may be listed
-        /// per request and all of them must be unique.
+        /// Asynchronously retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs
+        /// may be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="internalIds">The list of assets internal identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
@@ -329,8 +329,8 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs may be listed
-        /// per request and all of them must be unique.
+        /// Asynchronously retrieves information about multiple assets in the same project. A maximum of 1000 assets IDs
+        /// may be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="externalIds">The list of assets internal identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
@@ -360,7 +360,7 @@ namespace CogniteSdk.Resources
         #endregion
 
         /// <summary>
-        /// Retrieves a list of assets matching the given criteria. This operation does not support pagination.
+        /// Asynchronously retrieve a list of assets matching the given criteria. This operation does not support pagination.
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -385,7 +385,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves a list of assets matching the given criteria. This operation does not support pagination.
+        /// Retrieve a list of assets matching the given criteria. This operation does not support pagination.
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -396,8 +396,8 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Update one or more assets. Supports partial updates, meaning that fields omitted from the requests are not
-        /// changed
+        /// Asynchronously update one or more assets. Supports partial updates, meaning that fields omitted from the
+        /// requests are not changed
         /// </summary>
         /// <param name="query">The list of assets to update.</param>
         /// <param name="token">Optional cancellation token.</param>

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -27,7 +27,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously retrieves list of asset like objects matching the given query.
+        /// Asynchronously retrieve a list of asset like objects matching the given query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -45,7 +45,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously retrieves list of assets matching query.
+        /// Asynchronously retrieve a list of assets matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>

--- a/CogniteSdk/src/Resources/DataPoints.cs
+++ b/CogniteSdk/src/Resources/DataPoints.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Com.Cognite.V1.Timeseries.Proto;
-using static Oryx.Cognite.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -17,7 +17,7 @@ namespace CogniteSdk.Resources
     public class EventsResource : Resource
     {
         /// <summary>
-        /// Will only be instantiated by the client.
+        /// The class constructor. Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">Authentication handler.</param>
         /// <param name="includeMetadata">Include meta-data in responses or not.</param>
@@ -117,7 +117,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about an asset given an asset id.
+        /// Asynchronously retrieves information about an asset given an asset id.
         /// </summary>
         /// <param name="eventId">The id of the asset to get.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -150,7 +150,7 @@ namespace CogniteSdk.Resources
 
         #region Delete overloads
         /// <summary>
-        /// Delete multiple events in the same project.
+        /// Asynchronously delete multiple events in the same project.
         /// </summary>
         /// <param name="query">The list of events to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -176,7 +176,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple events in the same project.
+        /// Asynchronously delete multiple events in the same project.
         /// </summary>
         /// <param name="identities">The list of event ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -202,7 +202,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple events in the same project.
+        /// Asynchronously delete multiple events in the same project.
         /// </summary>
         /// <param name="ids">The list of event ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -228,7 +228,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple events in the same project.
+        /// Asynchronously delete multiple events in the same project.
         /// </summary>
         /// <param name="externalIds">The list of event externalids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -257,8 +257,8 @@ namespace CogniteSdk.Resources
 
         #region Retrieve overloads
         /// <summary>
-        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
-        /// per request and all of them must be unique.
+        /// Asynchronously retrieves information about multiple events in the same project. A maximum of 1000 events IDs
+        /// may be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="ids">The list of events to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
@@ -295,8 +295,8 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
-        /// per request and all of them must be unique.
+        /// Asynchronously retrieves information about multiple events in the same project. A maximum of 1000 events IDs
+        /// may be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="internalIds">The list of event internal ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
@@ -325,8 +325,8 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
-        /// per request and all of them must be unique.
+        /// Asynchronously retrieves information about multiple events in the same project. A maximum of 1000 events IDs
+        /// may be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="externalIds">The list of event external ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
@@ -357,7 +357,8 @@ namespace CogniteSdk.Resources
         #endregion
 
         /// <summary>
-        /// Retrieves a list of assets matching the given criteria. This operation does not support pagination.
+        /// Asynchronously retrieves a list of assets matching the given criteria. This operation does not support
+        /// pagination.
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -393,8 +394,8 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Update one or more events. Supports partial updates, meaning that fields omitted from the requests are not
-        /// changed
+        /// Asynchronously update one or more events. Supports partial updates, meaning that fields omitted from the
+        /// requests are not changed
         /// </summary>
         /// <param name="query">The list of events to update.</param>
         /// <param name="token">Optional cancellation token.</param>

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -33,15 +33,21 @@ namespace CogniteSdk.Resources
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>List of assets matching given filters and optional cursor</returns>
-        public async Task<ItemsWithCursor<Event>> ListAsync(EventQuery query, CancellationToken token = default)
+        public async Task<IItemsWithCursor<Event>> ListAsync(EventQuery query, CancellationToken token = default)
         {
             if (query is null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Oryx.Cognite.Events.list<Event, ItemsWithCursor<Event>>(query);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata)
+            {
+                var req = Oryx.Cognite.Events.list<Event, ItemsWithCursor<Event>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            } else {
+                var req = Oryx.Cognite.Events.list<EventWithoutMetadata, ItemsWithCursor<EventWithoutMetadata>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -50,7 +56,7 @@ namespace CogniteSdk.Resources
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>List of assets matching given filters and optional cursor</returns>
-        public ItemsWithCursor<Event> List(EventQuery query, CancellationToken token = default)
+        public IItemsWithCursor<Event> List(EventQuery query, CancellationToken token = default)
         {
             return ListAsync(query, token).GetAwaiter().GetResult();
         }
@@ -119,8 +125,17 @@ namespace CogniteSdk.Resources
         /// <returns>Asset with the given id.</returns>
         public async Task<Event> GetAsync(long eventId, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.Events.get<Event, Event>(eventId);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata)
+            {
+                var req = Oryx.Cognite.Events.get<Event, Event>(eventId);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
+            else
+            {
+                var req = Oryx.Cognite.Events.get<EventWithoutMetadata, EventWithoutMetadata>(eventId);
+                return await RunAsync(req, token).ConfigureAwait(false);
+
+            }
         }
 
         /// <summary>

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -21,8 +21,9 @@ namespace CogniteSdk.Resources
         /// Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">Authentication handler.</param>
+        /// <param name="includeMetadata">Include meta-data in responses or not.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal EventsResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
+        internal EventsResource(Func<CancellationToken, Task<string>> authHandler, bool includeMetadata, HttpContext ctx) : base(authHandler, includeMetadata, ctx)
         {
         }
 

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using static Oryx.Cognite.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -53,7 +53,7 @@ namespace CogniteSdk.Resources
             return (ItemsWithCursor<Event>) await ListAsync<Event>(query, token);
         }
 
-        // <summary>
+        /// <summary>
         /// Retrieves list of event like objects matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -27,7 +27,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves list of events matching query.
+        /// Asynchronously retrieves list of events matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -39,17 +39,28 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Oryx.Cognite.Events.list<ItemsWithCursor<Event>>(query);
+            var req = Oryx.Cognite.Events.list<Event, ItemsWithCursor<Event>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Retrieves number of events matching query.
+        /// Retrieves list of events matching query.
+        /// </summary>
+        /// <param name="query">The query filter to use.</param>
+        /// <param name="token">Optional cancellation token to use.</param>
+        /// <returns>List of assets matching given filters and optional cursor</returns>
+        public ItemsWithCursor<Event> List(EventQuery query, CancellationToken token = default)
+        {
+            return ListAsync(query, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves number of events matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>Number of assets matching given filters</returns>
-        public async Task<Int32> AggregateAsync(EventQuery query, CancellationToken token = default)
+        public async Task<int> AggregateAsync(EventQuery query, CancellationToken token = default)
         {
             if (query is null)
             {
@@ -61,7 +72,18 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Create events.
+        /// Retrieves number of events matching query.
+        /// </summary>
+        /// <param name="query">The query filter to use.</param>
+        /// <param name="token">Optional cancellation token to use.</param>
+        /// <returns>Number of assets matching given filters</returns>
+        public int Aggregate(EventQuery query, CancellationToken token = default)
+        {
+            return AggregateAsync(query, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously create events.
         /// </summary>
         /// <param name="events">Events to create.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -73,8 +95,19 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(events));
             }
 
-            var req = Oryx.Cognite.Events.create<IEnumerable<Event>>(events);
+            var req = Oryx.Cognite.Events.create<Event, IEnumerable<Event>>(events);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Create events.
+        /// </summary>
+        /// <param name="events">Events to create.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns></returns>
+        public IEnumerable<Event> Create(IEnumerable<EventCreate> events, CancellationToken token = default)
+        {
+            return CreateAsync(events, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -85,10 +118,20 @@ namespace CogniteSdk.Resources
         /// <returns>Asset with the given id.</returns>
         public async Task<Event> GetAsync(long eventId, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.Events.get<Event>(eventId);
+            var req = Oryx.Cognite.Events.get<Event, Event>(eventId);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieves information about an asset given an asset id.
+        /// </summary>
+        /// <param name="eventId">The id of the asset to get.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>Asset with the given id.</returns>
+        public Event Get(long eventId, CancellationToken token = default)
+        {
+            return GetAsync(eventId, token).GetAwaiter().GetResult();
+        }
 
         #region Delete overloads
         /// <summary>
@@ -110,6 +153,16 @@ namespace CogniteSdk.Resources
         /// <summary>
         /// Delete multiple events in the same project.
         /// </summary>
+        /// <param name="query">The list of events to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(EventDelete query, CancellationToken token = default)
+        {
+            return DeleteAsync(query, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Delete multiple events in the same project.
+        /// </summary>
         /// <param name="identities">The list of event ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<Identity> identities, CancellationToken token = default)
@@ -121,6 +174,16 @@ namespace CogniteSdk.Resources
 
             var query = new EventDelete { Items = identities };
             return await DeleteAsync(query, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Delete multiple events in the same project.
+        /// </summary>
+        /// <param name="identities">The list of event ids to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(IEnumerable<Identity> identities, CancellationToken token = default)
+        {
+            return DeleteAsync(identities, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -142,6 +205,16 @@ namespace CogniteSdk.Resources
         /// <summary>
         /// Delete multiple events in the same project.
         /// </summary>
+        /// <param name="ids">The list of event ids to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(IEnumerable<long> ids, CancellationToken token = default)
+        {
+            return DeleteAsync(ids, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Delete multiple events in the same project.
+        /// </summary>
         /// <param name="externalIds">The list of event externalids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<string> externalIds, CancellationToken token = default)
@@ -153,6 +226,16 @@ namespace CogniteSdk.Resources
 
             var query = new EventDelete { Items = externalIds.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Delete multiple events in the same project.
+        /// </summary>
+        /// <param name="externalIds">The list of event externalids to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(IEnumerable<string> externalIds, CancellationToken token = default)
+        {
+            return DeleteAsync(externalIds, token).GetAwaiter().GetResult();
         }
 
         #endregion
@@ -172,8 +255,20 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(ids));
             }
 
-            var req = Oryx.Cognite.Events.retrieve<IEnumerable<Event>>(ids, ignoreUnknownIds);
+            var req = Oryx.Cognite.Events.retrieve<Event, IEnumerable<Event>>(ids, ignoreUnknownIds);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
+        /// per request and all of them must be unique.
+        /// </summary>
+        /// <param name="ids">The list of events to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public IEnumerable<Event> Retrieve(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return RetrieveAsync(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -198,6 +293,18 @@ namespace CogniteSdk.Resources
         /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
         /// per request and all of them must be unique.
         /// </summary>
+        /// <param name="internalIds">The list of event internal ids to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public IEnumerable<Event> Retrieve(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return RetrieveAsync(internalIds, ignoreUnknownIds, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
+        /// per request and all of them must be unique.
+        /// </summary>
         /// <param name="externalIds">The list of event external ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -211,6 +318,19 @@ namespace CogniteSdk.Resources
             var req = externalIds.Select(Identity.Create);
             return await RetrieveAsync(req, ignoreUnknownIds, token).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
+        /// per request and all of them must be unique.
+        /// </summary>
+        /// <param name="externalIds">The list of event external ids to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public IEnumerable<Event> Retrieve(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return RetrieveAsync(externalIds, ignoreUnknownIds, token).GetAwaiter().GetResult();
+        }
+
         #endregion
 
         /// <summary>
@@ -226,8 +346,19 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Oryx.Cognite.Events.search<IEnumerable<Event>>(query);
+            var req = Oryx.Cognite.Events.search<Event, IEnumerable<Event>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves a list of assets matching the given criteria. This operation does not support pagination.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>List of assets matching given criteria.</returns>
+        public IEnumerable<Event> Search(EventSearch query, CancellationToken token = default)
+        {
+            return SearchAsync(query, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -244,8 +375,20 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Oryx.Cognite.Events.update<IEnumerable<Event>>(query);
+            var req = Oryx.Cognite.Events.update<Event, IEnumerable<Event>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Update one or more events. Supports partial updates, meaning that fields omitted from the requests are not
+        /// changed
+        /// </summary>
+        /// <param name="query">The list of events to update.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>List of updated assets.</returns>
+        public IEnumerable<Event> Update(IEnumerable<EventUpdateItem> query, CancellationToken token = default)
+        {
+            return UpdateAsync(query, token).GetAwaiter().GetResult();
         }
     }
 }

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -30,6 +30,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
+        /// <typeparam name="T">Type of event to return, e.g Event or EventWithoutMetadata.</typeparam>
         /// <returns>List of events matching given filters and optional cursor</returns>
         public async Task<IItemsWithCursor<T>> ListAsync<T>(EventQuery query, CancellationToken token = default) where T : Event
         {
@@ -92,6 +93,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="eventId">The id of the event to get.</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <typeparam name="T">Type of event to return, e.g Event or EventWithoutMetadata.</typeparam>
         /// <returns>Event with the given id.</returns>
         public async Task<T> GetAsync<T>(long eventId, CancellationToken token = default) where T : Event
         {
@@ -184,6 +186,8 @@ namespace CogniteSdk.Resources
         /// <param name="ids">The list of events to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <typeparam name="T">Type of event to return, e.g Event or EventWithoutMetadata.</typeparam>
+        /// <returns>A sequence of the requested events.</returns>
         public async Task<IEnumerable<T>> RetrieveAsync<T>(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : Event
         {
             if (ids is null)
@@ -202,6 +206,7 @@ namespace CogniteSdk.Resources
         /// <param name="ids">The list of events to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested events.</returns>
         public async Task<IEnumerable<Event>> RetrieveAsync(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             return await RetrieveAsync<Event>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
@@ -214,6 +219,7 @@ namespace CogniteSdk.Resources
         /// <param name="internalIds">The list of event internal ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested events.</returns>
         public async Task<IEnumerable<T>> RetrieveAsync<T>(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : Event
         {
             if (internalIds is null)
@@ -232,6 +238,7 @@ namespace CogniteSdk.Resources
         /// <param name="internalIds">The list of event internal ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested events.</returns>
         public async Task<IEnumerable<Event>> RetrieveAsync(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             return await RetrieveAsync<Event>(internalIds, ignoreUnknownIds, token).ConfigureAwait(false);

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -26,7 +26,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously retrieves list of event like objects matching query.
+        /// Asynchronously retrieve a list of event like objects matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -44,7 +44,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously retrieves list of events matching query.
+        /// Asynchronously retrieve a list of events matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -271,8 +271,16 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(ids));
             }
 
-            var req = Oryx.Cognite.Events.retrieve<Event, IEnumerable<Event>>(ids, ignoreUnknownIds);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata)
+            {
+                var req = Oryx.Cognite.Events.retrieve<Event, IEnumerable<Event>>(ids, ignoreUnknownIds);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
+            else
+            {
+                var req = Oryx.Cognite.Events.retrieve<EventWithoutMetadata, IEnumerable<EventWithoutMetadata>>(ids, ignoreUnknownIds);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -362,8 +370,16 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Oryx.Cognite.Events.search<Event, IEnumerable<Event>>(query);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata)
+            {
+                var req = Oryx.Cognite.Events.search<Event, IEnumerable<Event>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
+            else
+            {
+                var req = Oryx.Cognite.Events.search<EventWithoutMetadata, IEnumerable<EventWithoutMetadata>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/CogniteSdk/src/Resources/Events.cs
+++ b/CogniteSdk/src/Resources/Events.cs
@@ -50,29 +50,7 @@ namespace CogniteSdk.Resources
         /// <returns>List of events matching given filters and optional cursor</returns>
         public async Task<ItemsWithCursor<Event>> ListAsync(EventQuery query, CancellationToken token = default)
         {
-            return (ItemsWithCursor<Event>) await ListAsync<Event>(query, token);
-        }
-
-        /// <summary>
-        /// Retrieves list of event like objects matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>List of events matching given filters and optional cursor</returns>
-        public ItemsWithCursor<T> List<T>(EventQuery query, CancellationToken token = default) where T : Event
-        {
-            return (ItemsWithCursor<T>) ListAsync<T>(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieves list of events matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>List of events matching given filters and optional cursor</returns>
-        public ItemsWithCursor<Event> List(EventQuery query, CancellationToken token = default)
-        {
-            return (ItemsWithCursor<Event>) ListAsync<Event>(query, token).GetAwaiter().GetResult();
+            return (ItemsWithCursor<Event>) await ListAsync<Event>(query, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -93,17 +71,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves number of events matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>Number of events matching given filters</returns>
-        public int Aggregate(EventQuery query, CancellationToken token = default)
-        {
-            return AggregateAsync(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously create events.
         /// </summary>
         /// <param name="events">Events to create.</param>
@@ -118,17 +85,6 @@ namespace CogniteSdk.Resources
 
             var req = Oryx.Cognite.Events.create<Event, IEnumerable<Event>>(events);
             return await RunAsync(req, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Create events.
-        /// </summary>
-        /// <param name="events">Events to create.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>Sequence of created events</returns>
-        public IEnumerable<Event> Create(IEnumerable<EventCreate> events, CancellationToken token = default)
-        {
-            return CreateAsync(events, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -151,29 +107,7 @@ namespace CogniteSdk.Resources
         /// <returns>Event with the given id.</returns>
         public async Task<Event> GetAsync(long eventId, CancellationToken token = default)
         {
-            return await GetAsync<Event>(eventId, token);
-        }
-
-        /// <summary>
-        /// Retrieves information about an event like object given an event id.
-        /// </summary>
-        /// <param name="eventId">The id of the event to get.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>Event with the given id.</returns>
-        public T Get<T>(long eventId, CancellationToken token = default) where T : Event
-        {
-            return GetAsync<T>(eventId, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieves information about an event given an event id.
-        /// </summary>
-        /// <param name="eventId">The id of the event to get.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>Event with the given id.</returns>
-        public Event Get(long eventId, CancellationToken token = default)
-        {
-            return GetAsync<Event>(eventId, token).GetAwaiter().GetResult();
+            return await GetAsync<Event>(eventId, token).ConfigureAwait(false);
         }
 
         #region Delete overloads
@@ -194,16 +128,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple events in the same project.
-        /// </summary>
-        /// <param name="query">The list of events to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(EventDelete query, CancellationToken token = default)
-        {
-            return DeleteAsync(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously delete multiple events in the same project.
         /// </summary>
         /// <param name="identities">The list of event ids to delete.</param>
@@ -217,16 +141,6 @@ namespace CogniteSdk.Resources
 
             var query = new EventDelete { Items = identities };
             return await DeleteAsync(query, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Delete multiple events in the same project.
-        /// </summary>
-        /// <param name="identities">The list of event ids to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(IEnumerable<Identity> identities, CancellationToken token = default)
-        {
-            return DeleteAsync(identities, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -246,16 +160,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple events in the same project.
-        /// </summary>
-        /// <param name="ids">The list of event ids to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(IEnumerable<long> ids, CancellationToken token = default)
-        {
-            return DeleteAsync(ids, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously delete multiple events in the same project.
         /// </summary>
         /// <param name="externalIds">The list of event externalids to delete.</param>
@@ -270,17 +174,6 @@ namespace CogniteSdk.Resources
             var query = new EventDelete { Items = externalIds.Select(Identity.Create) };
             return await DeleteAsync(query, token).ConfigureAwait(false);
         }
-
-        /// <summary>
-        /// Delete multiple events in the same project.
-        /// </summary>
-        /// <param name="externalIds">The list of event externalids to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(IEnumerable<string> externalIds, CancellationToken token = default)
-        {
-            return DeleteAsync(externalIds, token).GetAwaiter().GetResult();
-        }
-
         #endregion
 
         #region Retrieve overloads
@@ -311,19 +204,7 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Event>> RetrieveAsync(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
-            return await RetrieveAsync<Event>(ids, ignoreUnknownIds, token);
-        }
-
-        /// <summary>
-        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
-        /// per request and all of them must be unique.
-        /// </summary>
-        /// <param name="ids">The list of events to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<T> Retrieve<T>(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : Event
-        {
-            return RetrieveAsync<T>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
+            return await RetrieveAsync<Event>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -353,19 +234,7 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<Event>> RetrieveAsync(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
-            return await RetrieveAsync<Event>(internalIds, ignoreUnknownIds, token);
-        }
-
-        /// <summary>
-        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
-        /// per request and all of them must be unique.
-        /// </summary>
-        /// <param name="internalIds">The list of event internal ids to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<Event> Retrieve(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
-        {
-            return RetrieveAsync<Event>(internalIds, ignoreUnknownIds, token).GetAwaiter().GetResult();
+            return await RetrieveAsync<Event>(internalIds, ignoreUnknownIds, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -385,33 +254,6 @@ namespace CogniteSdk.Resources
             var req = externalIds.Select(Identity.Create);
             return await RetrieveAsync<Event>(req, ignoreUnknownIds, token).ConfigureAwait(false);
         }
-
-        /// <summary>
-        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
-        /// per request and all of them must be unique.
-        /// </summary>
-        /// <param name="externalIds">The list of event external ids to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<T> Retrieve<T>(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : Event
-        {
-            var ids = externalIds.Select(Identity.Create);
-            return RetrieveAsync<T>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieves information about multiple events in the same project. A maximum of 1000 events IDs may be listed
-        /// per request and all of them must be unique.
-        /// </summary>
-        /// <param name="externalIds">The list of event external ids to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<Event> Retrieve(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
-        {
-            var ids = externalIds.Select(Identity.Create);
-            return RetrieveAsync<Event>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
         #endregion
 
         /// <summary>
@@ -446,29 +288,7 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return await SearchAsync<Event>(query, token);
-        }
-
-        /// <summary>
-        /// Retrieves a list of events matching the given criteria. This operation does not support pagination.
-        /// </summary>
-        /// <param name="query">Search query.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of events matching given criteria.</returns>
-        public IEnumerable<T> Search<T>(EventSearch query, CancellationToken token = default) where T : Event
-        {
-            return SearchAsync<T>(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieves a list of events matching the given criteria. This operation does not support pagination.
-        /// </summary>
-        /// <param name="query">Search query.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of events matching given criteria.</returns>
-        public IEnumerable<Event> Search(EventSearch query, CancellationToken token = default)
-        {
-            return SearchAsync(query, token).GetAwaiter().GetResult();
+            return await SearchAsync<Event>(query, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -487,18 +307,6 @@ namespace CogniteSdk.Resources
 
             var req = Oryx.Cognite.Events.update<Event, IEnumerable<Event>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Update one or more events. Supports partial updates, meaning that fields omitted from the requests are not
-        /// changed
-        /// </summary>
-        /// <param name="query">The list of events to update.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of updated events.</returns>
-        public IEnumerable<Event> Update(IEnumerable<EventUpdateItem> query, CancellationToken token = default)
-        {
-            return UpdateAsync(query, token).GetAwaiter().GetResult();
         }
     }
 }

--- a/CogniteSdk/src/Resources/Files.cs
+++ b/CogniteSdk/src/Resources/Files.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using static Oryx.Cognite.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources

--- a/CogniteSdk/src/Resources/Playground/Assets.cs
+++ b/CogniteSdk/src/Resources/Playground/Assets.cs
@@ -27,7 +27,7 @@ namespace CogniteSdk.Resources.Playground
         }
 
         /// <summary>
-        /// Asynchronously retrieves list of assets matching query.
+        /// Asynchronously retrieve a list of assets matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>

--- a/CogniteSdk/src/Resources/Playground/Assets.cs
+++ b/CogniteSdk/src/Resources/Playground/Assets.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Oryx.Cognite.Playground;
-using static Oryx.Cognite.Playground.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources.Playground

--- a/CogniteSdk/src/Resources/Playground/Assets.cs
+++ b/CogniteSdk/src/Resources/Playground/Assets.cs
@@ -18,7 +18,7 @@ namespace CogniteSdk.Resources.Playground
     public class AssetsResource : Resource
     {
         /// <summary>
-        /// Will only be instantiated by the client.
+        /// The class constructor. Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">Authentication handler.</param>
         /// <param name="ctx">Context to use for the request.</param>
@@ -27,7 +27,7 @@ namespace CogniteSdk.Resources.Playground
         }
 
         /// <summary>
-        /// Retrieves list of assets matching query.
+        /// Asynchronously retrieves list of assets matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>

--- a/CogniteSdk/src/Resources/Playground/FunctionCalls.cs
+++ b/CogniteSdk/src/Resources/Playground/FunctionCalls.cs
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
 using CogniteSdk;
 using Oryx.Cognite.Playground;
-using static Oryx.Cognite.Playground.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources.Playground

--- a/CogniteSdk/src/Resources/Playground/FunctionSchedules.cs
+++ b/CogniteSdk/src/Resources/Playground/FunctionSchedules.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CogniteSdk;
 using Oryx.Cognite.Playground;
-using static Oryx.Cognite.Playground.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources.Playground

--- a/CogniteSdk/src/Resources/Playground/Functions.cs
+++ b/CogniteSdk/src/Resources/Playground/Functions.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CogniteSdk;
 using Oryx.Cognite.Playground;
-using static Oryx.Cognite.Playground.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources.Playground

--- a/CogniteSdk/src/Resources/Playground/Relationships.cs
+++ b/CogniteSdk/src/Resources/Playground/Relationships.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CogniteSdk;
-using static Oryx.Cognite.Playground.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources.Playground

--- a/CogniteSdk/src/Resources/Resource.cs
+++ b/CogniteSdk/src/Resources/Resource.cs
@@ -27,24 +27,6 @@ namespace CogniteSdk.Resources
         protected readonly Func<CancellationToken, Task<string>> _authHandler;
 
         /// <summary>
-        /// Include metadata or not.
-        /// </summary>
-        protected readonly bool _includeMetadata;
-
-        /// <summary>
-        /// Will only be instantiated by the client.
-        /// </summary>
-        /// <param name="authHandler">Authentication handler.</param>
-        /// <param name="includeMetadata">Include meta-data or not.</param>
-        /// <param name="ctx">Context to use for the request.</param>
-        internal Resource(Func<CancellationToken, Task<string>> authHandler, bool includeMetadata, HttpContext ctx)
-        {
-            _ctx = ctx;
-            _authHandler = authHandler;
-            _includeMetadata = includeMetadata;
-        }
-
-        /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">Authentication handler.</param>
@@ -53,7 +35,6 @@ namespace CogniteSdk.Resources
         {
             _ctx = ctx;
             _authHandler = authHandler;
-            _includeMetadata = true;
         }
 
         /// <summary>

--- a/CogniteSdk/src/Resources/Resource.cs
+++ b/CogniteSdk/src/Resources/Resource.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -55,6 +53,7 @@ namespace CogniteSdk.Resources
         {
             _ctx = ctx;
             _authHandler = authHandler;
+            _includeMetadata = true;
         }
 
         /// <summary>

--- a/CogniteSdk/src/Resources/Resource.cs
+++ b/CogniteSdk/src/Resources/Resource.cs
@@ -29,6 +29,24 @@ namespace CogniteSdk.Resources
         protected readonly Func<CancellationToken, Task<string>> _authHandler;
 
         /// <summary>
+        /// Include metadata or not.
+        /// </summary>
+        protected readonly bool _includeMetadata;
+
+        /// <summary>
+        /// Will only be instantiated by the client.
+        /// </summary>
+        /// <param name="authHandler">Authentication handler.</param>
+        /// <param name="includeMetadata">Include meta-data or not.</param>
+        /// <param name="ctx">Context to use for the request.</param>
+        internal Resource(Func<CancellationToken, Task<string>> authHandler, bool includeMetadata, HttpContext ctx)
+        {
+            _ctx = ctx;
+            _authHandler = authHandler;
+            _includeMetadata = includeMetadata;
+        }
+
+        /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">Authentication handler.</param>

--- a/CogniteSdk/src/Resources/Sequences.cs
+++ b/CogniteSdk/src/Resources/Sequences.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using static Oryx.Cognite.HandlerModule;
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
 
 namespace CogniteSdk.Resources

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -17,7 +17,7 @@ namespace CogniteSdk.Resources
     public class TimeSeriesResource : Resource
     {
         /// <summary>
-        /// Will only be instantiated by the client.
+        /// The class constructor. Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">The authentication handler.</param>
         /// <param name="includeMetadata">Include meta-data in responses or not.</param>
@@ -27,7 +27,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves list of time series matching query.
+        /// Asynchronously retrieve list of time series matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -47,7 +47,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves list of time series matching query.
+        /// Retrieve list of time series matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -58,7 +58,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves number of timeseries matching query.
+        /// Asynchronously retrieve the number of timeseries matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -75,7 +75,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves number of timeseries matching query.
+        /// Retrieve the number of timeseries matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -86,7 +86,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Create 1 or more time series.
+        /// Asynchronously create one or more time series.
         /// </summary>
         /// <param name="timeseries">Time series to create.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -98,7 +98,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Create 1 or more time series.
+        /// Create one or more time series.
         /// </summary>
         /// <param name="timeseries">Time series to create.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -109,7 +109,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple times eries in the same project.
+        /// Asynchronously delete multiple times series in the same project.
         /// </summary>
         /// <param name="query">The list of timeseries to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -120,7 +120,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple times eries in the same project.
+        /// Delete multiple times series in the same project.
         /// </summary>
         /// <param name="query">The list of timeseries to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -130,7 +130,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple times eries in the same project.
+        /// Asynchronously delete multiple times eries in the same project.
         /// </summary>
         /// <param name="internalIds">The list of timeseries internal ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -152,7 +152,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple times eries in the same project.
+        /// Asynchronously delete multiple times eries in the same project.
         /// </summary>
         /// <param name="externalIds">The list of timeseries external ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -174,8 +174,8 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
-        /// be listed per request and all of them must be unique.
+        /// Asynchronously retrieve information about multiple time series in the same project. A maximum of 1000 time
+        /// series IDs may be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="ids">The list of time series identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
@@ -195,7 +195,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
+        /// Retrieve information about multiple time series in the same project. A maximum of 1000 time series IDs may
         /// be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="ids">The list of time series identities to retrieve.</param>
@@ -207,8 +207,8 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
-        /// be listed per request and all of them must be unique.
+        /// Asynchronously retrieve information about multiple time series in the same project. A maximum of 1000 time
+        /// series IDs may be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="internalIds">The list of time series internal ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
@@ -220,7 +220,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
+        /// Retrieve information about multiple time series in the same project. A maximum of 1000 time series IDs may
         /// be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="internalIds">The list of time series internal ids to retrieve.</param>
@@ -232,8 +232,8 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
-        /// be listed per request and all of them must be unique.
+        /// Asynchronously retrieve information about multiple time series in the same project. A maximum of 1000 time
+        /// series IDs may be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="externalIds">The list of time series internal ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
@@ -245,7 +245,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
+        /// Retrieve information about multiple time series in the same project. A maximum of 1000 time series IDs may
         /// be listed per request and all of them must be unique.
         /// </summary>
         /// <param name="externalIds">The list of time series internal ids to retrieve.</param>
@@ -257,7 +257,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves a list of time series matching the given criteria. This operation does not support pagination.
+        /// Asynchronously retrieve a list of time series matching the given criteria. This operation does not support pagination.
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -282,7 +282,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves a list of time series matching the given criteria. This operation does not support pagination.
+        /// Retrieve a list of time series matching the given criteria. This operation does not support pagination.
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -293,7 +293,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Updates multiple time series within the same project. This operation supports partial updates, meaning that
+        /// Asynchronously update multiple time series within the same project. This operation supports partial updates, meaning that
         /// fields omitted from the requests are not changed
         /// </summary>
         /// <param name="query">The list of timeseries to update.</param>
@@ -311,7 +311,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Updates multiple time series within the same project. This operation supports partial updates, meaning that
+        /// Update multiple time series within the same project. This operation supports partial updates, meaning that
         /// fields omitted from the requests are not changed
         /// </summary>
         /// <param name="query">The list of timeseries to update.</param>
@@ -323,7 +323,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves list of time series matching query.
+        /// Asynchronously retrieve a list of time series matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -340,7 +340,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieves list of time series matching query.
+        /// Retrieve a list of time series matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -43,9 +43,9 @@ namespace CogniteSdk.Resources
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>List of time series matching given filters and optional cursor</returns>
-        public async Task<IItemsWithCursor<TimeSeries>> ListAsync(TimeSeriesQuery query, CancellationToken token = default)
+        public async Task<ItemsWithCursor<TimeSeries>> ListAsync(TimeSeriesQuery query, CancellationToken token = default)
         {
-            return await ListAsync<TimeSeries>(query, token);
+            return (ItemsWithCursor<TimeSeries>) await ListAsync<TimeSeries>(query, token);
         }
 
         /// <summary>

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -41,12 +41,23 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
+        /// Retrieves list of time series matching query.
+        /// </summary>
+        /// <param name="query">The query filter to use.</param>
+        /// <param name="token">Optional cancellation token to use.</param>
+        /// <returns>List of time series matching given filters and optional cursor</returns>
+        public ItemsWithCursor<TimeSeries> List(TimeSeriesQuery query, CancellationToken token = default)
+        {
+            return ListAsync(query, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Retrieves number of timeseries matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>Number of timeseries matching given filters</returns>
-        public async Task<Int32> AggregateAsync(TimeSeriesQuery query, CancellationToken token = default)
+        public async Task<int> AggregateAsync(TimeSeriesQuery query, CancellationToken token = default)
         {
             if (query is null)
             {
@@ -55,6 +66,17 @@ namespace CogniteSdk.Resources
 
             var req = Oryx.Cognite.TimeSeries.aggregate<Int32>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves number of timeseries matching query.
+        /// </summary>
+        /// <param name="query">The query filter to use.</param>
+        /// <param name="token">Optional cancellation token to use.</param>
+        /// <returns>Number of timeseries matching given filters</returns>
+        public int Aggregate(TimeSeriesQuery query, CancellationToken token = default)
+        {
+            return AggregateAsync(query, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -70,6 +92,17 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
+        /// Create 1 or more time series.
+        /// </summary>
+        /// <param name="timeseries">Time series to create.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns></returns>
+        public IEnumerable<TimeSeries> Create(IEnumerable<TimeSeriesCreate> timeseries, CancellationToken token = default)
+        {
+            return CreateAsync(timeseries, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Delete multiple times eries in the same project.
         /// </summary>
         /// <param name="query">The list of timeseries to delete.</param>
@@ -78,6 +111,16 @@ namespace CogniteSdk.Resources
         {
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Delete multiple times eries in the same project.
+        /// </summary>
+        /// <param name="query">The list of timeseries to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(TimeSeriesDelete query, CancellationToken token = default)
+        {
+            return DeleteAsync(query, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -95,6 +138,16 @@ namespace CogniteSdk.Resources
         /// <summary>
         /// Delete multiple times eries in the same project.
         /// </summary>
+        /// <param name="internalIds">The list of timeseries internal ids to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(IEnumerable<long> internalIds, CancellationToken token = default)
+        {
+            return DeleteAsync(internalIds, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Delete multiple times eries in the same project.
+        /// </summary>
         /// <param name="externalIds">The list of timeseries external ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<string> externalIds, CancellationToken token = default)
@@ -102,6 +155,16 @@ namespace CogniteSdk.Resources
             var query = new TimeSeriesDelete { Items=externalIds.Select(Identity.Create) };
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Delete multiple times eries in the same project.
+        /// </summary>
+        /// <param name="externalIds">The list of timeseries external ids to delete.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public EmptyResponse Delete(IEnumerable<string> externalIds, CancellationToken token = default)
+        {
+            return DeleteAsync(externalIds, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -115,6 +178,18 @@ namespace CogniteSdk.Resources
         {
             var req = Oryx.Cognite.TimeSeries.retrieve<TimeSeries, IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
+        /// be listed per request and all of them must be unique.
+        /// </summary>
+        /// <param name="ids">The list of time series identities to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public IEnumerable<TimeSeries> Retrieve(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return RetrieveAsync(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -135,6 +210,18 @@ namespace CogniteSdk.Resources
         /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
         /// be listed per request and all of them must be unique.
         /// </summary>
+        /// <param name="internalIds">The list of time series internal ids to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public IEnumerable<TimeSeries> Retrieve(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return RetrieveAsync(internalIds, ignoreUnknownIds, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
+        /// be listed per request and all of them must be unique.
+        /// </summary>
         /// <param name="externalIds">The list of time series internal ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -146,12 +233,24 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
+        /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may
+        /// be listed per request and all of them must be unique.
+        /// </summary>
+        /// <param name="externalIds">The list of time series internal ids to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        public IEnumerable<TimeSeries> Retrieve(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return RetrieveAsync(externalIds, ignoreUnknownIds, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Retrieves a list of time series matching the given criteria. This operation does not support pagination.
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
         /// <returns>List of assets matching given criteria.</returns>
-        public async Task<IEnumerable<TimeSeries>> SearchAsync (TimeSeriesSearch query, CancellationToken token = default )
+        public async Task<IEnumerable<TimeSeries>> SearchAsync(TimeSeriesSearch query, CancellationToken token = default)
         {
             if (query is null)
             {
@@ -163,13 +262,24 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
+        /// Retrieves a list of time series matching the given criteria. This operation does not support pagination.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>List of assets matching given criteria.</returns>
+        public IEnumerable<TimeSeries> Search(TimeSeriesSearch query, CancellationToken token = default)
+        {
+            return SearchAsync(query, token).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Updates multiple time series within the same project. This operation supports partial updates, meaning that
         /// fields omitted from the requests are not changed
         /// </summary>
         /// <param name="query">The list of timeseries to update.</param>
         /// <param name="token">Optional cancellation token.</param>
         /// <returns>List of updated timeseries.</returns>
-        public async Task<IEnumerable<TimeSeries>> UpdateAsync (IEnumerable<TimeSeriesUpdateItem> query, CancellationToken token = default )
+        public async Task<IEnumerable<TimeSeries>> UpdateAsync(IEnumerable<TimeSeriesUpdateItem> query, CancellationToken token = default )
         {
             if (query is null)
             {
@@ -178,6 +288,18 @@ namespace CogniteSdk.Resources
 
             var req = Oryx.Cognite.TimeSeries.update<TimeSeries, IEnumerable<TimeSeries>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Updates multiple time series within the same project. This operation supports partial updates, meaning that
+        /// fields omitted from the requests are not changed
+        /// </summary>
+        /// <param name="query">The list of timeseries to update.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>List of updated timeseries.</returns>
+        public IEnumerable<TimeSeries> Update(IEnumerable<TimeSeriesUpdateItem> query, CancellationToken token = default )
+        {
+            return UpdateAsync(query, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -195,6 +317,17 @@ namespace CogniteSdk.Resources
 
             var req = Oryx.Cognite.TimeSeries.syntheticQuery<IEnumerable<DataPointsSyntheticItem>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves list of time series matching query.
+        /// </summary>
+        /// <param name="query">The query filter to use.</param>
+        /// <param name="token">Optional cancellation token to use.</param>
+        /// <returns>List of assets matching given filters and optional cursor</returns>
+        public IEnumerable<DataPointsSyntheticItem> SyntheticQuery(TimeSeriesSyntheticQuery query, CancellationToken token = default)
+        {
+            return SyntheticQueryAsync(query, token).GetAwaiter().GetResult();
         }
     }
 }

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -23,8 +23,9 @@ namespace CogniteSdk.Resources
         /// Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">The authentication handler.</param>
+        /// <param name="includeMetadata">Include meta-data in responses or not.</param>
         /// <param name="ctx">Context to use for the request.</param>
-        internal TimeSeriesResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
+        internal TimeSeriesResource(Func<CancellationToken, Task<string>> authHandler, bool includeMetadata, HttpContext ctx) : base(authHandler, includeMetadata, ctx)
         {
         }
 

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -1,16 +1,13 @@
 // Copyright 2019 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using static Oryx.Cognite.HandlerModule;
-using CogniteSdk;
-
 using HttpContext = Oryx.Context<System.Net.Http.HttpResponseMessage>;
-using System;
 
 namespace CogniteSdk.Resources
 {

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -101,7 +101,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously delete multiple times series in the same project.
+        /// Asynchronously delete multiple time series in the same project.
         /// </summary>
         /// <param name="query">The list of timeseries to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -112,7 +112,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously delete multiple times eries in the same project.
+        /// Asynchronously delete multiple times series in the same project.
         /// </summary>
         /// <param name="internalIds">The list of timeseries internal ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
@@ -124,7 +124,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously delete multiple times eries in the same project.
+        /// Asynchronously delete multiple time series in the same project.
         /// </summary>
         /// <param name="externalIds">The list of timeseries external ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -35,10 +35,18 @@ namespace CogniteSdk.Resources
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>List of time series matching given filters and optional cursor</returns>
-        public async Task<ItemsWithCursor<TimeSeries>> ListAsync(TimeSeriesQuery query, CancellationToken token = default)
+        public async Task<IItemsWithCursor<TimeSeries>> ListAsync(TimeSeriesQuery query, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.TimeSeries.list<TimeSeries,  ItemsWithCursor<TimeSeries>>(query);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata)
+            {
+                var req = Oryx.Cognite.TimeSeries.list<TimeSeries,  ItemsWithCursor<TimeSeries>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
+            else
+            {
+                var req = Oryx.Cognite.TimeSeries.list<TimeSeriesWithoutMetadata,  ItemsWithCursor<TimeSeriesWithoutMetadata>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -47,7 +55,7 @@ namespace CogniteSdk.Resources
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
         /// <returns>List of time series matching given filters and optional cursor</returns>
-        public ItemsWithCursor<TimeSeries> List(TimeSeriesQuery query, CancellationToken token = default)
+        public IItemsWithCursor<TimeSeries> List(TimeSeriesQuery query, CancellationToken token = default)
         {
             return ListAsync(query, token).GetAwaiter().GetResult();
         }

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -30,6 +30,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
+        /// <typeparam name="T">Type of asset to return, e.g Assset or AssetWithoutMetadata.</typeparam>
         /// <returns>List of time series matching given filters and optional cursor</returns>
         public async Task<IItemsWithCursor<T>> ListAsync<T>(TimeSeriesQuery query, CancellationToken token = default) where T : TimeSeries
         {
@@ -49,7 +50,7 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously retrieve the number of timeseries matching query.
+        /// Asynchronously retrieve the number of time series matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
@@ -82,6 +83,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="tsId">The id of the time series to get.</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <typeparam name="T">Type of time series to return, e.g TimeSeries or TimeSeriesWithoutMetadata.</typeparam>
         /// <returns>Time series with the given id.</returns>
         public async Task<T> GetAsync<T>(long tsId, CancellationToken token = default) where T : TimeSeries
         {
@@ -103,7 +105,7 @@ namespace CogniteSdk.Resources
         /// <summary>
         /// Asynchronously delete multiple time series in the same project.
         /// </summary>
-        /// <param name="query">The list of timeseries to delete.</param>
+        /// <param name="query">The list of time series to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(TimeSeriesDelete query, CancellationToken token = default)
         {
@@ -112,9 +114,9 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Asynchronously delete multiple times series in the same project.
+        /// Asynchronously delete multiple time series in the same project.
         /// </summary>
-        /// <param name="internalIds">The list of timeseries internal ids to delete.</param>
+        /// <param name="internalIds">The list of time series internal ids to delete.</param>
         /// <param name="token">Optional cancellation token.</param>
         public async Task<EmptyResponse> DeleteAsync(IEnumerable<long> internalIds, CancellationToken token = default)
         {
@@ -141,6 +143,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="ids">The list of time series identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <typeparam name="T">Type of time series to return, e.g TimeSeries or TimeSeriesWithoutMetadata.</typeparam>
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<T>> RetrieveAsync<T>(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : TimeSeries
         {
@@ -155,6 +158,7 @@ namespace CogniteSdk.Resources
         /// <param name="ids">The list of time series identities to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested time series.</returns>
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             return await RetrieveAsync<TimeSeries>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
@@ -167,6 +171,7 @@ namespace CogniteSdk.Resources
         /// <param name="internalIds">The list of time series internal ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested time series.</returns>
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             var ids = internalIds.Select(Identity.Create);
@@ -180,6 +185,7 @@ namespace CogniteSdk.Resources
         /// <param name="externalIds">The list of time series internal ids to retrieve.</param>
         /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested time series.</returns>
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             var ids = externalIds.Select(Identity.Create);
@@ -192,7 +198,8 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of time series matching given criteria.</returns>
+        /// <typeparam name="T">Type of time series to return, e.g TimeSeries or TimeSeriesWithoutMetadata.</typeparam>
+        /// <returns>Sequence of time series matching given criteria.</returns>
         public async Task<IEnumerable<T>> SearchAsync<T>(TimeSeriesSearch query, CancellationToken token = default) where T : TimeSeries
         {
             if (query is null)

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -36,7 +36,7 @@ namespace CogniteSdk.Resources
         /// <returns>List of time series matching given filters and optional cursor</returns>
         public async Task<ItemsWithCursor<TimeSeries>> ListAsync(TimeSeriesQuery query, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.TimeSeries.list<ItemsWithCursor<TimeSeries>>(query);
+            var req = Oryx.Cognite.TimeSeries.list<TimeSeries,  ItemsWithCursor<TimeSeries>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
@@ -65,7 +65,7 @@ namespace CogniteSdk.Resources
         /// <returns></returns>
         public async Task<IEnumerable<TimeSeries>> CreateAsync(IEnumerable<TimeSeriesCreate> timeseries, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.TimeSeries.create<IEnumerable<TimeSeries>>(timeseries);
+            var req = Oryx.Cognite.TimeSeries.create<TimeSeries, IEnumerable<TimeSeries>>(timeseries);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
@@ -113,7 +113,7 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.TimeSeries.retrieve<IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
+            var req = Oryx.Cognite.TimeSeries.retrieve<TimeSeries, IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
@@ -127,7 +127,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             var ids = internalIds.Select(Identity.Create);
-            var req = Oryx.Cognite.TimeSeries.retrieve<IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
+            var req = Oryx.Cognite.TimeSeries.retrieve<TimeSeries, IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
@@ -141,7 +141,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             var ids = externalIds.Select(Identity.Create);
-            var req = Oryx.Cognite.TimeSeries.retrieve<IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
+            var req = Oryx.Cognite.TimeSeries.retrieve<TimeSeries, IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
@@ -158,7 +158,7 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Oryx.Cognite.TimeSeries.search<IEnumerable<TimeSeries>>(query);
+            var req = Oryx.Cognite.TimeSeries.search<TimeSeries, IEnumerable<TimeSeries>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 
@@ -176,7 +176,7 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Oryx.Cognite.TimeSeries.update<IEnumerable<TimeSeries>>(query);
+            var req = Oryx.Cognite.TimeSeries.update<TimeSeries, IEnumerable<TimeSeries>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -78,6 +78,29 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
+        /// Asynchronously retrieve information about an time series like object given a time series id.
+        /// </summary>
+        /// <param name="tsId">The id of the time series to get.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>Time series with the given id.</returns>
+        public async Task<T> GetAsync<T>(long tsId, CancellationToken token = default) where T : TimeSeries
+        {
+            var req = Oryx.Cognite.TimeSeries.get<T, T>(tsId);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieve information about an time series given a time series id.
+        /// </summary>
+        /// <param name="tsId">The id of the time series to get.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>Time series with the given id.</returns>
+        public async Task<TimeSeries> GetAsync(long tsId, CancellationToken token = default)
+        {
+            return await GetAsync<TimeSeries>(tsId, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Asynchronously delete multiple times series in the same project.
         /// </summary>
         /// <param name="query">The list of timeseries to delete.</param>
@@ -169,7 +192,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of assets matching given criteria.</returns>
+        /// <returns>List of time series matching given criteria.</returns>
         public async Task<IEnumerable<T>> SearchAsync<T>(TimeSeriesSearch query, CancellationToken token = default) where T : TimeSeries
         {
             if (query is null)
@@ -187,7 +210,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">Search query.</param>
         /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of assets matching given criteria.</returns>
+        /// <returns>List of time series matching given criteria.</returns>
         public async Task<IEnumerable<TimeSeries>> SearchAsync(TimeSeriesSearch query, CancellationToken token = default)
         {
             return await SearchAsync<TimeSeries>(query, token).ConfigureAwait(false);
@@ -216,7 +239,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>List of assets matching given filters and optional cursor</returns>
+        /// <returns>List of time series matching given filters and optional cursor</returns>
         public async Task<IEnumerable<DataPointsSyntheticItem>> SyntheticQueryAsync(TimeSeriesSyntheticQuery query, CancellationToken token = default)
         {
             if (query is null)

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -185,8 +185,16 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
-            var req = Oryx.Cognite.TimeSeries.retrieve<TimeSeries, IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata)
+            {
+                var req = Oryx.Cognite.TimeSeries.retrieve<TimeSeries, IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
+            else
+            {
+                var req = Oryx.Cognite.TimeSeries.retrieve<TimeSeriesWithoutMetadata, IEnumerable<TimeSeriesWithoutMetadata>>(ids, ignoreUnknownIds);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -211,8 +219,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             var ids = internalIds.Select(Identity.Create);
-            var req = Oryx.Cognite.TimeSeries.retrieve<TimeSeries, IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            return await RetrieveAsync(ids, ignoreUnknownIds, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -237,8 +244,7 @@ namespace CogniteSdk.Resources
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
             var ids = externalIds.Select(Identity.Create);
-            var req = Oryx.Cognite.TimeSeries.retrieve<TimeSeries, IEnumerable<TimeSeries>>(ids, ignoreUnknownIds);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            return await RetrieveAsync(ids, ignoreUnknownIds, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -266,8 +272,16 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Oryx.Cognite.TimeSeries.search<TimeSeries, IEnumerable<TimeSeries>>(query);
-            return await RunAsync(req, token).ConfigureAwait(false);
+            if (_includeMetadata)
+            {
+                var req = Oryx.Cognite.TimeSeries.search<TimeSeries, IEnumerable<TimeSeries>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
+            else
+            {
+                var req = Oryx.Cognite.TimeSeries.search<TimeSeriesWithoutMetadata, IEnumerable<TimeSeriesWithoutMetadata>>(query);
+                return await RunAsync(req, token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/CogniteSdk/src/Resources/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/TimeSeries.cs
@@ -45,29 +45,7 @@ namespace CogniteSdk.Resources
         /// <returns>List of time series matching given filters and optional cursor</returns>
         public async Task<ItemsWithCursor<TimeSeries>> ListAsync(TimeSeriesQuery query, CancellationToken token = default)
         {
-            return (ItemsWithCursor<TimeSeries>) await ListAsync<TimeSeries>(query, token);
-        }
-
-        /// <summary>
-        /// Retrieve list of time series like objects matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>List of time series matching given filters and optional cursor</returns>
-        public IItemsWithCursor<T> List<T>(TimeSeriesQuery query, CancellationToken token = default) where T : TimeSeries
-        {
-            return ListAsync<T>(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieve list of time series matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>List of time series matching given filters and optional cursor</returns>
-        public IItemsWithCursor<TimeSeries> List(TimeSeriesQuery query, CancellationToken token = default)
-        {
-            return ListAsync<TimeSeries>(query, token).GetAwaiter().GetResult();
+            return (ItemsWithCursor<TimeSeries>) await ListAsync<TimeSeries>(query, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -83,19 +61,8 @@ namespace CogniteSdk.Resources
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var req = Oryx.Cognite.TimeSeries.aggregate<Int32>(query);
+            var req = Oryx.Cognite.TimeSeries.aggregate<int>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Retrieve the number of timeseries matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>Number of timeseries matching given filters</returns>
-        public int Aggregate(TimeSeriesQuery query, CancellationToken token = default)
-        {
-            return AggregateAsync(query, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -111,17 +78,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Create one or more time series.
-        /// </summary>
-        /// <param name="timeseries">Time series to create.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns></returns>
-        public IEnumerable<TimeSeries> Create(IEnumerable<TimeSeriesCreate> timeseries, CancellationToken token = default)
-        {
-            return CreateAsync(timeseries, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously delete multiple times series in the same project.
         /// </summary>
         /// <param name="query">The list of timeseries to delete.</param>
@@ -130,16 +86,6 @@ namespace CogniteSdk.Resources
         {
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Delete multiple times series in the same project.
-        /// </summary>
-        /// <param name="query">The list of timeseries to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(TimeSeriesDelete query, CancellationToken token = default)
-        {
-            return DeleteAsync(query, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -155,16 +101,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Delete multiple times eries in the same project.
-        /// </summary>
-        /// <param name="internalIds">The list of timeseries internal ids to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(IEnumerable<long> internalIds, CancellationToken token = default)
-        {
-            return DeleteAsync(internalIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously delete multiple times eries in the same project.
         /// </summary>
         /// <param name="externalIds">The list of timeseries external ids to delete.</param>
@@ -174,16 +110,6 @@ namespace CogniteSdk.Resources
             var query = new TimeSeriesDelete { Items=externalIds.Select(Identity.Create) };
             var req = Oryx.Cognite.TimeSeries.delete<EmptyResponse>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Delete multiple times series in the same project.
-        /// </summary>
-        /// <param name="externalIds">The list of timeseries external ids to delete.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public EmptyResponse Delete(IEnumerable<string> externalIds, CancellationToken token = default)
-        {
-            return DeleteAsync(externalIds, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -208,31 +134,7 @@ namespace CogniteSdk.Resources
         /// <param name="token">Optional cancellation token.</param>
         public async Task<IEnumerable<TimeSeries>> RetrieveAsync(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
         {
-            return await RetrieveAsync<TimeSeries>(ids, ignoreUnknownIds, token);
-        }
-
-        /// <summary>
-        /// Retrieve information about multiple time series in the same project. A maximum of 1000 time series IDs may
-        /// be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="ids">The list of time series identities to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<T> Retrieve<T>(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default) where T :  TimeSeries
-        {
-            return RetrieveAsync<T>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieve information about multiple time series in the same project. A maximum of 1000 time series IDs may
-        /// be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="ids">The list of time series identities to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<TimeSeries> Retrieve(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
-        {
-            return RetrieveAsync<TimeSeries>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
+            return await RetrieveAsync<TimeSeries>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -249,31 +151,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Retrieve information about multiple time series like objects in the same project. A maximum of 1000 time series IDs may
-        /// be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="internalIds">The list of time series internal ids to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<T> Retrieve<T>(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : TimeSeries
-        {
-            var ids = internalIds.Select(Identity.Create);
-            return RetrieveAsync<T>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieve information about multiple time series in the same project. A maximum of 1000 time series IDs may
-        /// be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="internalIds">The list of time series internal ids to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<TimeSeries> Retrieve(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
-        {
-            return RetrieveAsync(internalIds, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously retrieve information about multiple time series in the same project. A maximum of 1000 time
         /// series IDs may be listed per request and all of them must be unique.
         /// </summary>
@@ -284,31 +161,6 @@ namespace CogniteSdk.Resources
         {
             var ids = externalIds.Select(Identity.Create);
             return await RetrieveAsync(ids, ignoreUnknownIds, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Retrieve information about multiple time series like objects in the same project. A maximum of 1000 time
-        /// series IDs may be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="externalIds">The list of time series internal ids to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<T> Retrieve<T>(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : TimeSeries
-        {
-            var ids = externalIds.Select(Identity.Create);
-            return RetrieveAsync<T>(ids, ignoreUnknownIds, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieve information about multiple time series in the same project. A maximum of 1000 time series IDs may
-        /// be listed per request and all of them must be unique.
-        /// </summary>
-        /// <param name="externalIds">The list of time series internal ids to retrieve.</param>
-        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
-        /// <param name="token">Optional cancellation token.</param>
-        public IEnumerable<TimeSeries> Retrieve(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
-        {
-            return RetrieveAsync(externalIds, ignoreUnknownIds, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -338,30 +190,7 @@ namespace CogniteSdk.Resources
         /// <returns>List of assets matching given criteria.</returns>
         public async Task<IEnumerable<TimeSeries>> SearchAsync(TimeSeriesSearch query, CancellationToken token = default)
         {
-            return await SearchAsync<TimeSeries>(query, token);
-        }
-
-        /// <summary>
-        /// Retrieve a list of time series like objects matching the given criteria. This operation does not support
-        /// pagination.
-        /// </summary>
-        /// <param name="query">Search query.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of assets matching given criteria.</returns>
-        public IEnumerable<T> Search<T>(TimeSeriesSearch query, CancellationToken token = default) where T : TimeSeries
-        {
-            return SearchAsync<T>(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Retrieve a list of time series matching the given criteria. This operation does not support pagination.
-        /// </summary>
-        /// <param name="query">Search query.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of assets matching given criteria.</returns>
-        public IEnumerable<TimeSeries> Search(TimeSeriesSearch query, CancellationToken token = default)
-        {
-            return SearchAsync<TimeSeries>(query, token).GetAwaiter().GetResult();
+            return await SearchAsync<TimeSeries>(query, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -383,18 +212,6 @@ namespace CogniteSdk.Resources
         }
 
         /// <summary>
-        /// Update multiple time series within the same project. This operation supports partial updates, meaning that
-        /// fields omitted from the requests are not changed
-        /// </summary>
-        /// <param name="query">The list of timeseries to update.</param>
-        /// <param name="token">Optional cancellation token.</param>
-        /// <returns>List of updated timeseries.</returns>
-        public IEnumerable<TimeSeries> Update(IEnumerable<TimeSeriesUpdateItem> query, CancellationToken token = default )
-        {
-            return UpdateAsync(query, token).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
         /// Asynchronously retrieve a list of time series matching query.
         /// </summary>
         /// <param name="query">The query filter to use.</param>
@@ -409,17 +226,6 @@ namespace CogniteSdk.Resources
 
             var req = Oryx.Cognite.TimeSeries.syntheticQuery<IEnumerable<DataPointsSyntheticItem>>(query);
             return await RunAsync(req, token).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Retrieve a list of time series matching query.
-        /// </summary>
-        /// <param name="query">The query filter to use.</param>
-        /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>List of assets matching given filters and optional cursor</returns>
-        public IEnumerable<DataPointsSyntheticItem> SyntheticQuery(TimeSeriesSyntheticQuery query, CancellationToken token = default)
-        {
-            return SyntheticQueryAsync(query, token).GetAwaiter().GetResult();
         }
     }
 }

--- a/CogniteSdk/test/csharp/Assets.cs
+++ b/CogniteSdk/test/csharp/Assets.cs
@@ -7,15 +7,15 @@ using Xunit;
 
 using CogniteSdk;
 
-namespace Test.CSharp.Integration {
-
+namespace Test.CSharp.Integration
+{
     [Collection("TestBase")]
-    public class AssetTests : TestFixture {
-
-
+    public class AssetTests : TestFixture
+    {
         [Fact]
         [Trait("Description", "Ensures listing Assets returns number of assets equal to 'limit' value")]
-        public void ListingAssetsRespectsLimit() {
+        public void ListingAssetsRespectsLimit()
+        {
             // Arrange
             const int limit = 10;
             var option = new AssetQuery
@@ -29,9 +29,11 @@ namespace Test.CSharp.Integration {
             // Assert
             Assert.True(limit == res.Items.Count(), "Expected the number of assets to be the same as the Limit value");
         }
+
         [Fact]
         [Trait("Description", "Ensures that getting the Asset count matching the query returns a number")]
-        public void CountAssetsReturnInt() {
+        public void CountAssetsReturnInt()
+        {
             // Arrange
             var option = new AssetQuery {
                 Filter = new AssetFilter(){
@@ -46,9 +48,11 @@ namespace Test.CSharp.Integration {
             // Assert
             Assert.True(count > 0);
         }
+
         [Fact]
         [Trait("Description", "Ensures that getting the Asset count when filter has no matches returns zero")]
-        public void CountAssetsWithNoMatchesReturnZero() {
+        public void CountAssetsWithNoMatchesReturnZero()
+        {
             // Arrange
             var option = new AssetQuery {
                 Filter = new AssetFilter(){
@@ -67,7 +71,8 @@ namespace Test.CSharp.Integration {
         [Fact]
         [Trait("Description","Ensures that getting an asset by ID returns the correct asset")]
 
-        public void AssetByIdReturnsCorrectAsset() {
+        public void AssetByIdReturnsCorrectAsset()
+        {
             // Arrange
             const long assetId = 130452390632424;
 
@@ -80,7 +85,8 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Ensures that getting an asset with an invalid Id doesnt return anything")]
-        public void AssetByInvalidIdReturnsError() {
+        public void AssetByInvalidIdReturnsError()
+        {
             // Arrange
             var assetId = 0;
             bool caughtException = false;
@@ -98,7 +104,8 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Gets multiple Assets with a list of ids and ensures they are the correct assets")]
-        public void AssetsByIdsRetrivesTheCorrectAssetsAsync() {
+        public void AssetsByIdsRetrivesTheCorrectAssetsAsync()
+        {
             // Arrange
             var ids = new List<long>() {
                 130452390632424,
@@ -118,7 +125,8 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Search Asset returns the correct number of assets")]
-        public void AssetSearchReturnsExpectedNumberOfAssets() {
+        public void AssetSearchReturnsExpectedNumberOfAssets()
+        {
             // Arrange
             var numOfAssets = 10;
             var query = new AssetSearch()
@@ -140,7 +148,8 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Listing Assets with filter returns the expected number of assets")]
-        public void FilterAssetsReturnsTheExpectedNumberOfAssets() {
+        public void FilterAssetsReturnsTheExpectedNumberOfAssets()
+        {
             // Arrange
             var numOfAssets = 10;
             var id = 6687602007296940;
@@ -161,7 +170,8 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Creating an asset and deletes it works")]
-        public void CreateAndDeleteAssetWorkAsExpected() {
+        public void CreateAndDeleteAssetWorkAsExpected()
+        {
             // Arrange
             var externalIdString = Guid.NewGuid().ToString();
             var newAsset = new AssetCreate
@@ -187,7 +197,8 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Deleting an asset that does not exist fails with ResponseException")]
-        public void AssetDeleteFailsWhenIdIsInvalid() {
+        public void AssetDeleteFailsWhenIdIsInvalid()
+        {
             // Arrange
             var id = 0;
             var caughtException = false;
@@ -210,7 +221,8 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Updating asset performs expected changes")]
-        public void UpdatedAssetsPerformsExpectedChanges() {
+        public void UpdatedAssetsPerformsExpectedChanges()
+        {
             // Arrange
             var externalIdString = Guid.NewGuid().ToString();
             var newMetadata = new Dictionary<string, string>() {
@@ -257,7 +269,8 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Updating assets label performs expected changes")]
-        public async Task UpdatedAssetsLabelPerformsExpectedChangesAsync() {
+        public async Task UpdatedAssetsLabelPerformsExpectedChangesAsync()
+        {
             // Arrange
             var externalIdString = Guid.NewGuid().ToString();
 

--- a/CogniteSdk/test/csharp/Assets.cs
+++ b/CogniteSdk/test/csharp/Assets.cs
@@ -14,7 +14,7 @@ namespace Test.CSharp.Integration
     {
         [Fact]
         [Trait("Description", "Ensures listing Assets returns number of assets equal to 'limit' value")]
-        public async Task ListingAssetsRespectsLimit()
+        public async Task ListingAssetsRespectsLimitAsync()
         {
             // Arrange
             const int limit = 10;
@@ -32,7 +32,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Ensures that getting the Asset count matching the query returns a number")]
-        public async Task CountAssetsReturnInt()
+        public async Task CountAssetsReturnIntAsync()
         {
             // Arrange
             var option = new AssetQuery {
@@ -51,7 +51,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Ensures that getting the Asset count when filter has no matches returns zero")]
-        public async Task CountAssetsWithNoMatchesReturnZero()
+        public async Task CountAssetsWithNoMatchesReturnZeroAsync()
         {
             // Arrange
             var option = new AssetQuery {
@@ -71,7 +71,7 @@ namespace Test.CSharp.Integration
         [Fact]
         [Trait("Description","Ensures that getting an asset by ID returns the correct asset")]
 
-        public async Task AssetByIdReturnsCorrectAsset()
+        public async Task AssetByIdReturnsCorrectAssetAsync()
         {
             // Arrange
             const long assetId = 130452390632424;
@@ -85,7 +85,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Ensures that getting an asset with an invalid Id doesnt return anything")]
-        public async Task AssetByInvalidIdReturnsError()
+        public async Task AssetByInvalidIdReturnsErrorAsync()
         {
             // Arrange
             var assetId = 0;
@@ -125,7 +125,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Search Asset returns the correct number of assets")]
-        public async Task AssetSearchReturnsExpectedNumberOfAssets()
+        public async Task AssetSearchReturnsExpectedNumberOfAssetsAsync()
         {
             // Arrange
             var numOfAssets = 10;
@@ -148,7 +148,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Listing Assets with filter returns the expected number of assets")]
-        public async Task FilterAssetsReturnsTheExpectedNumberOfAssets()
+        public async Task FilterAssetsReturnsTheExpectedNumberOfAssetsAsync()
         {
             // Arrange
             var numOfAssets = 10;
@@ -170,7 +170,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Creating an asset and deletes it works")]
-        public async Task CreateAndDeleteAssetWorkAsExpected()
+        public async Task CreateAndDeleteAssetWorkAsExpectedAsync()
         {
             // Arrange
             var externalIdString = Guid.NewGuid().ToString();
@@ -197,7 +197,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Deleting an asset that does not exist fails with ResponseException")]
-        public async Task AssetDeleteFailsWhenIdIsInvalid()
+        public async Task AssetDeleteFailsWhenIdIsInvalidAsync()
         {
             // Arrange
             var id = 0;
@@ -221,7 +221,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Updating asset performs expected changes")]
-        public async Task UpdatedAssetsPerformsExpectedChanges()
+        public async Task UpdatedAssetsPerformsExpectedChangesAsync()
         {
             // Arrange
             var externalIdString = Guid.NewGuid().ToString();

--- a/CogniteSdk/test/csharp/Assets.cs
+++ b/CogniteSdk/test/csharp/Assets.cs
@@ -14,7 +14,7 @@ namespace Test.CSharp.Integration
     {
         [Fact]
         [Trait("Description", "Ensures listing Assets returns number of assets equal to 'limit' value")]
-        public void ListingAssetsRespectsLimit()
+        public async Task ListingAssetsRespectsLimit()
         {
             // Arrange
             const int limit = 10;
@@ -24,7 +24,7 @@ namespace Test.CSharp.Integration
             };
 
             // Act
-            var res = ReadClient.Assets.List(option);
+            var res = await ReadClient.Assets.ListAsync(option);
 
             // Assert
             Assert.True(limit == res.Items.Count(), "Expected the number of assets to be the same as the Limit value");
@@ -32,7 +32,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Ensures that getting the Asset count matching the query returns a number")]
-        public void CountAssetsReturnInt()
+        public async Task CountAssetsReturnInt()
         {
             // Arrange
             var option = new AssetQuery {
@@ -43,7 +43,7 @@ namespace Test.CSharp.Integration
                 }
             };
             // Act
-            var count = ReadClient.Assets.Aggregate(option);
+            var count = await ReadClient.Assets.AggregateAsync(option);
 
             // Assert
             Assert.True(count > 0);
@@ -51,7 +51,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Ensures that getting the Asset count when filter has no matches returns zero")]
-        public void CountAssetsWithNoMatchesReturnZero()
+        public async Task CountAssetsWithNoMatchesReturnZero()
         {
             // Arrange
             var option = new AssetQuery {
@@ -62,7 +62,7 @@ namespace Test.CSharp.Integration
                 }
             };
             // Act
-            var count = ReadClient.Assets.Aggregate(option);
+            var count = await ReadClient.Assets.AggregateAsync(option);
 
             // Assert
             Assert.True(count == 0);
@@ -71,13 +71,13 @@ namespace Test.CSharp.Integration
         [Fact]
         [Trait("Description","Ensures that getting an asset by ID returns the correct asset")]
 
-        public void AssetByIdReturnsCorrectAsset()
+        public async Task AssetByIdReturnsCorrectAsset()
         {
             // Arrange
             const long assetId = 130452390632424;
 
             // Act
-            var res = ReadClient.Assets.Get(assetId);
+            var res = await ReadClient.Assets.GetAsync(assetId);
 
             // Assert
             Assert.True(assetId == res.Id, "The received Asset doesn't match the ID");
@@ -85,7 +85,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Ensures that getting an asset with an invalid Id doesnt return anything")]
-        public void AssetByInvalidIdReturnsError()
+        public async Task AssetByInvalidIdReturnsError()
         {
             // Arrange
             var assetId = 0;
@@ -93,7 +93,7 @@ namespace Test.CSharp.Integration
 
             // Act
             try {
-                var res = ReadClient.Assets.Get(assetId);
+                var res = await ReadClient.Assets.GetAsync(assetId);
             } catch (ResponseException) {
                 caughtException = true;
             }
@@ -104,7 +104,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Gets multiple Assets with a list of ids and ensures they are the correct assets")]
-        public void AssetsByIdsRetrivesTheCorrectAssetsAsync()
+        public async Task AssetsByIdsRetrivesTheCorrectAssetsAsync()
         {
             // Arrange
             var ids = new List<long>() {
@@ -114,7 +114,7 @@ namespace Test.CSharp.Integration
             };
 
             // Act
-            var res = ReadClient.Assets.Retrieve(ids);
+            var res = await ReadClient.Assets.RetrieveAsync(ids);
 
             // Assert
             var returnedIds = res.Select(asset => asset.Id);
@@ -125,7 +125,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Search Asset returns the correct number of assets")]
-        public void AssetSearchReturnsExpectedNumberOfAssets()
+        public async Task AssetSearchReturnsExpectedNumberOfAssets()
         {
             // Arrange
             var numOfAssets = 10;
@@ -139,7 +139,7 @@ namespace Test.CSharp.Integration
             };
 
             // Act
-            var res = ReadClient.Assets.Search(query);
+            var res = await ReadClient.Assets.SearchAsync(query);
 
             // Assert
             var resCount = res.Count();
@@ -148,7 +148,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Listing Assets with filter returns the expected number of assets")]
-        public void FilterAssetsReturnsTheExpectedNumberOfAssets()
+        public async Task FilterAssetsReturnsTheExpectedNumberOfAssets()
         {
             // Arrange
             var numOfAssets = 10;
@@ -161,7 +161,7 @@ namespace Test.CSharp.Integration
             };
 
             // Act
-            var res = ReadClient.Assets.List(query);
+            var res = await ReadClient.Assets.ListAsync(query);
 
             // Assert
             var resCount = res.Items.Count();
@@ -170,7 +170,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Creating an asset and deletes it works")]
-        public void CreateAndDeleteAssetWorkAsExpected()
+        public async Task CreateAndDeleteAssetWorkAsExpected()
         {
             // Arrange
             var externalIdString = Guid.NewGuid().ToString();
@@ -186,8 +186,8 @@ namespace Test.CSharp.Integration
             };
 
             // Act
-            var res = WriteClient.Assets.Create(new List<AssetCreate>() { newAsset });
-            WriteClient.Assets.Delete(deletes);
+            var res = await WriteClient.Assets.CreateAsync(new List<AssetCreate>() { newAsset });
+            await WriteClient.Assets.DeleteAsync(deletes);
 
             // Assert
             var resCount = res.Count();
@@ -197,7 +197,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Deleting an asset that does not exist fails with ResponseException")]
-        public void AssetDeleteFailsWhenIdIsInvalid()
+        public async Task AssetDeleteFailsWhenIdIsInvalid()
         {
             // Arrange
             var id = 0;
@@ -210,7 +210,7 @@ namespace Test.CSharp.Integration
 
             // Act
             try {
-                WriteClient.Assets.Delete(query);
+                await WriteClient.Assets.DeleteAsync(query);
             } catch (ResponseException) {
                 caughtException = true;
             }
@@ -221,7 +221,7 @@ namespace Test.CSharp.Integration
 
         [Fact]
         [Trait("Description", "Updating asset performs expected changes")]
-        public void UpdatedAssetsPerformsExpectedChanges()
+        public async Task UpdatedAssetsPerformsExpectedChanges()
         {
             // Arrange
             var externalIdString = Guid.NewGuid().ToString();
@@ -251,11 +251,11 @@ namespace Test.CSharp.Integration
             };
 
             // Act
-            _ = WriteClient.Assets.Create(new List<AssetCreate>() { newAsset });
-            WriteClient.Assets.Update(update);
+            await WriteClient.Assets.CreateAsync(new List<AssetCreate>() { newAsset });
+            await WriteClient.Assets.UpdateAsync(update);
 
-            var getRes = WriteClient.Assets.Retrieve(new List<string>() { externalIdString });
-            WriteClient.Assets.Delete(new List<string>() { externalIdString });
+            var getRes = await WriteClient.Assets.RetrieveAsync(new List<string>() { externalIdString });
+            await WriteClient.Assets.DeleteAsync(new List<string>() { externalIdString });
 
             // Assert
             var resCount = getRes.Count();

--- a/CogniteSdk/test/csharp/Assets.cs
+++ b/CogniteSdk/test/csharp/Assets.cs
@@ -24,10 +24,10 @@ namespace Test.CSharp.Integration {
             };
 
             // Act
-            var res = ReadClient.Assets.ListAsync(option);
+            var res = ReadClient.Assets.List(option);
 
             // Assert
-            Assert.True(limit == res.Result.Items.Count(), "Expected the number of assets to be the same as the Limit value");
+            Assert.True(limit == res.Items.Count(), "Expected the number of assets to be the same as the Limit value");
         }
         [Fact]
         [Trait("Description", "Ensures that getting the Asset count matching the query returns a number")]
@@ -41,10 +41,9 @@ namespace Test.CSharp.Integration {
                 }
             };
             // Act
-            var res = ReadClient.Assets.AggregateAsync(option);
+            var count = ReadClient.Assets.Aggregate(option);
 
             // Assert
-            var count = res.Result;
             Assert.True(count > 0);
         }
         [Fact]
@@ -59,22 +58,21 @@ namespace Test.CSharp.Integration {
                 }
             };
             // Act
-            var res = ReadClient.Assets.AggregateAsync(option);
+            var count = ReadClient.Assets.Aggregate(option);
 
             // Assert
-            var count = res.Result;
             Assert.True(count == 0);
         }
 
         [Fact]
         [Trait("Description","Ensures that getting an asset by ID returns the correct asset")]
 
-        public async Task AssetByIdReturnsCorrectAssetAsync() {
+        public void AssetByIdReturnsCorrectAsset() {
             // Arrange
             const long assetId = 130452390632424;
 
             // Act
-            var res = await ReadClient.Assets.GetAsync(assetId);
+            var res = ReadClient.Assets.Get(assetId);
 
             // Assert
             Assert.True(assetId == res.Id, "The received Asset doesn't match the ID");
@@ -82,14 +80,14 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Ensures that getting an asset with an invalid Id doesnt return anything")]
-        public async Task AssetByInvalidIdReturnsErrorAsync() {
+        public void AssetByInvalidIdReturnsError() {
             // Arrange
             var assetId = 0;
             bool caughtException = false;
 
             // Act
             try {
-                var res = await ReadClient.Assets.GetAsync(assetId);
+                var res = ReadClient.Assets.Get(assetId);
             } catch (ResponseException) {
                 caughtException = true;
             }
@@ -99,8 +97,8 @@ namespace Test.CSharp.Integration {
         }
 
         [Fact]
-        [Trait("Description", "Gets multiple Assets with a list of ids and ensures theyre the correct assets")]
-        public async Task AssetsByIdsRetrivesTheCorrectAssetsAsync() {
+        [Trait("Description", "Gets multiple Assets with a list of ids and ensures they are the correct assets")]
+        public void AssetsByIdsRetrivesTheCorrectAssetsAsync() {
             // Arrange
             var ids = new List<long>() {
                 130452390632424,
@@ -109,7 +107,7 @@ namespace Test.CSharp.Integration {
             };
 
             // Act
-            var res = await ReadClient.Assets.RetrieveAsync(ids);
+            var res = ReadClient.Assets.Retrieve(ids);
 
             // Assert
             var returnedIds = res.Select(asset => asset.Id);
@@ -120,7 +118,7 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Search Asset returns the correct number of assets")]
-        public async Task AssetSearchReturnsExpectedNumberOfAssetsAsync() {
+        public void AssetSearchReturnsExpectedNumberOfAssets() {
             // Arrange
             var numOfAssets = 10;
             var query = new AssetSearch()
@@ -133,7 +131,7 @@ namespace Test.CSharp.Integration {
             };
 
             // Act
-            var res = await ReadClient.Assets.SearchAsync(query);
+            var res = ReadClient.Assets.Search(query);
 
             // Assert
             var resCount = res.Count();
@@ -142,7 +140,7 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Listing Assets with filter returns the expected number of assets")]
-        public async Task FilterAssetsReturnsTheExpectedNumberOfAssetsAsync() {
+        public void FilterAssetsReturnsTheExpectedNumberOfAssets() {
             // Arrange
             var numOfAssets = 10;
             var id = 6687602007296940;
@@ -154,7 +152,7 @@ namespace Test.CSharp.Integration {
             };
 
             // Act
-            var res = await ReadClient.Assets.ListAsync(query);
+            var res = ReadClient.Assets.List(query);
 
             // Assert
             var resCount = res.Items.Count();
@@ -163,7 +161,7 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Creating an asset and deletes it works")]
-        public async Task CreateAndDeleteAssetWorkAsExpectedAsync() {
+        public void CreateAndDeleteAssetWorkAsExpected() {
             // Arrange
             var externalIdString = Guid.NewGuid().ToString();
             var newAsset = new AssetCreate
@@ -178,8 +176,8 @@ namespace Test.CSharp.Integration {
             };
 
             // Act
-            var res = await WriteClient.Assets.CreateAsync(new List<AssetCreate>() { newAsset });
-            await WriteClient.Assets.DeleteAsync(deletes);
+            var res = WriteClient.Assets.Create(new List<AssetCreate>() { newAsset });
+            WriteClient.Assets.Delete(deletes);
 
             // Assert
             var resCount = res.Count();
@@ -189,7 +187,7 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Deleting an asset that does not exist fails with ResponseException")]
-        public async Task AssetDeleteFailsWhenIdIsInvalidAsync() {
+        public void AssetDeleteFailsWhenIdIsInvalid() {
             // Arrange
             var id = 0;
             var caughtException = false;
@@ -201,7 +199,7 @@ namespace Test.CSharp.Integration {
 
             // Act
             try {
-                await WriteClient.Assets.DeleteAsync(query);
+                WriteClient.Assets.Delete(query);
             } catch (ResponseException) {
                 caughtException = true;
             }
@@ -212,7 +210,7 @@ namespace Test.CSharp.Integration {
 
         [Fact]
         [Trait("Description", "Updating asset performs expected changes")]
-        public async Task UpdatedAssetsPerformsExpectedChangesAsync() {
+        public void UpdatedAssetsPerformsExpectedChanges() {
             // Arrange
             var externalIdString = Guid.NewGuid().ToString();
             var newMetadata = new Dictionary<string, string>() {
@@ -241,11 +239,11 @@ namespace Test.CSharp.Integration {
             };
 
             // Act
-            _ = await WriteClient.Assets.CreateAsync(new List<AssetCreate>() { newAsset }).ConfigureAwait(false);
-            await WriteClient.Assets.UpdateAsync(update);
+            _ = WriteClient.Assets.Create(new List<AssetCreate>() { newAsset });
+            WriteClient.Assets.Update(update);
 
-            var getRes = await WriteClient.Assets.RetrieveAsync(new List<string>() { externalIdString });
-            await WriteClient.Assets.DeleteAsync(new List<string>() { externalIdString });
+            var getRes = WriteClient.Assets.Retrieve(new List<string>() { externalIdString });
+            WriteClient.Assets.Delete(new List<string>() { externalIdString });
 
             // Assert
             var resCount = getRes.Count();

--- a/CogniteSdk/test/csharp/Sequences.cs
+++ b/CogniteSdk/test/csharp/Sequences.cs
@@ -28,6 +28,7 @@ namespace Test.CSharp.Integration
             // Assert
             Assert.True(res.Items.Any(), "Expected at least one sequence");
         }
+
         [Fact]
         [Trait("Description", "List Sequences with limit and filter is Ok")]
         public async Task ListSequenceWithLimitAndFilter()
@@ -48,6 +49,7 @@ namespace Test.CSharp.Integration
             // Assert
             Assert.True(res.Items.Any(), "Expected at least one sequence");
         }
+
         [Fact]
         [Trait("Description", "Retrieve Sequences by id is Ok")]
         public async Task RetrieveSequenceById()

--- a/CogniteSdk/test/csharp/TestBase.cs
+++ b/CogniteSdk/test/csharp/TestBase.cs
@@ -9,14 +9,15 @@ using Xunit;
 
 namespace Test.CSharp.Integration
 {
-
-    public class TestFixture : IDisposable {
+    public class TestFixture : IDisposable
+    {
 
         protected static Client ReadClient;
         protected static Client WriteClient;
         protected static Event TestEvent;
 
-        public TestFixture() {
+        public TestFixture()
+        {
             ReadClient = CreateClient(Environment.GetEnvironmentVariable("TEST_API_KEY_READ"), "publicdata", "https://api.cognitedata.com");
             WriteClient = CreateClient(Environment.GetEnvironmentVariable("TEST_API_KEY_WRITE"), "fusiondotnet-tests", "https://greenfield.cognitedata.com");
 
@@ -25,7 +26,8 @@ namespace Test.CSharp.Integration
 
         public void Dispose() { }
 
-        private static Client CreateClient(string apiKey, string project, string url) {
+        private static Client CreateClient(string apiKey, string project, string url)
+        {
             var httpClient = new HttpClient();
             return Client.Builder.Create(httpClient)
                 .SetAppId("TestApp")
@@ -35,7 +37,8 @@ namespace Test.CSharp.Integration
                 .Build();
         }
 
-        private void PopulateDataAsync() {
+        private void PopulateDataAsync()
+        {
             try {
                 TestEvent = WriteClient.Events.RetrieveAsync(new List<string>() { "TestEvent" }).Result.FirstOrDefault();
             } catch (AggregateException) {

--- a/CogniteSdk/test/fsharp/Assets.fs
+++ b/CogniteSdk/test/fsharp/Assets.fs
@@ -56,7 +56,7 @@ let ``Get asset without metadata is Ok`` () =
     let assetId = 130452390632424L
 
     // Act
-    let res = readClientWithoutMetadata.Assets.Get assetId
+    let res = readClient.Assets.Get<AssetWithoutMetadata> assetId
 
     let resId = res.Id
 

--- a/CogniteSdk/test/fsharp/Assets.fs
+++ b/CogniteSdk/test/fsharp/Assets.fs
@@ -37,6 +37,36 @@ let ``Get asset by id is Ok`` () =
     test <@ resId = assetId @>
 
 [<Fact>]
+let ``Get asset with metadata is Ok`` () =
+    // Arrange
+    let assetId = 130452390632424L
+
+    // Act
+    let res = readClient.Assets.Get assetId
+
+    let md = res.Metadata
+
+    // Assert
+    test <@ not (isNull md) @>
+    test <@ md.["SOURCE_DB"] = "workmate" @>
+
+[<Fact>]
+let ``Get asset without metadata is Ok`` () =
+    // Arrange
+    let assetId = 130452390632424L
+
+    // Act
+    let res = readClientWithoutMetadata.Assets.Get assetId
+
+    let resId = res.Id
+
+    // Assert
+    let md = res.Metadata
+
+    // Assert
+    test <@ isNull md @>
+
+[<Fact>]
 let ``Get asset by missing id is Error`` () =
     // Arrange
     let assetId = 0L

--- a/CogniteSdk/test/fsharp/Assets.fs
+++ b/CogniteSdk/test/fsharp/Assets.fs
@@ -123,13 +123,13 @@ let ``Filter assets is Ok`` () = task {
 }
 
 [<Fact>]
-let ``Filter assets on Name is Ok`` () =
+let ``Filter assets on Name is Ok`` () = task {
     // Arrange
     let filter = AssetFilter(Name = "23-TE-96116-04")
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = readClient.Assets.List query
+    let! res = readClient.Assets.ListAsync query
 
     let len = Seq.length res.Items
     let identity = (Seq.head res.Items).Id
@@ -137,15 +137,16 @@ let ``Filter assets on Name is Ok`` () =
     // Assert
     test <@ len = 1 @>
     test <@ identity = 702630644612L @>
+}
 
 [<Fact>]
-let ``Filter assets on ExternalIdPrefix is Ok`` () =
+let ``Filter assets on ExternalIdPrefix is Ok`` () = task {
     // Arrange
     let filter = AssetFilter(ExternalIdPrefix = "odata")
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = writeClient.Assets.List query
+    let! res = writeClient.Assets.ListAsync query
 
     let len = Seq.length res.Items
 
@@ -156,16 +157,17 @@ let ``Filter assets on ExternalIdPrefix is Ok`` () =
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun (e: string) -> e.StartsWith "odata") externalids @>
+}
 
 [<Fact>]
-let ``Filter assets on MetaData is Ok`` () =
+let ``Filter assets on MetaData is Ok`` () = task {
     // Arrange
     let meta = Dictionary (dict [("RES_ID", "525283")])
     let filter = AssetFilter(Metadata = meta)
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = readClient.Assets.List query
+    let! res = readClient.Assets.ListAsync query
 
     let len = Seq.length res.Items
     let ms = Seq.map (fun (dto: Asset) -> dto.Metadata) res.Items
@@ -173,6 +175,7 @@ let ``Filter assets on MetaData is Ok`` () =
     // Assert
     test <@ len = 10 @>
     test <@ ms |> Seq.forall (fun (m: Dictionary<string, string>) -> (m.Item "RES_ID") = "525283") @>
+}
 
 [<Fact>]
 let ``Filter assets on ParentIds is Ok`` () = task {
@@ -404,10 +407,10 @@ let ``Update assets is Ok`` () = task {
     }
 
     // Act
-    let createRes = writeClient.Assets.Create [ dto ]
-    let updateRes = writeClient.Assets.Update update
+    let! createRes = writeClient.Assets.CreateAsync [ dto ]
+    let! updateRes = writeClient.Assets.UpdateAsync update
 
-    let assetsResponses = writeClient.Assets.Retrieve [ newExternalId ]
+    let! assetsResponses = writeClient.Assets.RetrieveAsync [ newExternalId ]
 
     let resName, resExternalId, resMetaData =
         let h = Seq.tryHead assetsResponses
@@ -493,7 +496,7 @@ let ``Filter assets on single Label is Ok`` () = task {
     let query = AssetQuery(Limit = Nullable 1000, Filter = filter)
 
     // Act
-    let res = writeClient.Assets.List query
+    let! res = writeClient.Assets.ListAsync query
 
     let allItemsMatch =
         res.Items |> Seq.map (fun item ->
@@ -556,7 +559,7 @@ let ``Filter assets with labels AND filter is Ok`` () = task {
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = writeClient.Assets.List query
+    let! res = writeClient.Assets.ListAsync query
 
     // Assert
     let resLabels =

--- a/CogniteSdk/test/fsharp/Assets.fs
+++ b/CogniteSdk/test/fsharp/Assets.fs
@@ -12,46 +12,42 @@ open CogniteSdk
 open Common
 
 [<Fact>]
-let ``List assets with limit is Ok`` () = task {
+let ``List assets with limit is Ok`` () =
     // Arrange
     let query = AssetQuery(Limit= Nullable 10)
 
     // Act
-    let! res = readClient.Assets.ListAsync(query)
+    let res = readClient.Assets.List(query)
     let len = Seq.length res.Items
 
     // Assert
     test <@ len = 10 @>
-}
 
 [<Fact>]
-let ``Get asset by id is Ok`` () = task {
+let ``Get asset by id is Ok`` () =
     // Arrange
     let assetId = 130452390632424L
 
     // Act
-    let! res = readClient.Assets.GetAsync assetId
+    let res = readClient.Assets.Get assetId
 
     let resId = res.Id
 
     // Assert
     test <@ resId = assetId @>
-}
 
 [<Fact>]
-let ``Get asset by missing id is Error`` () = task {
+let ``Get asset by missing id is Error`` () =
     // Arrange
     let assetId = 0L
 
     // Act
-    let! res =
-        task {
-            try
-                let! a = readClient.Assets.GetAsync assetId
-                return Ok a
-            with
-            | :? ResponseException as e -> return Error e
-        }
+    let res =
+        try
+            let a = readClient.Assets.Get assetId
+            Ok a
+        with
+        | :? ResponseException as e -> Error e
 
     let err = Result.getError res
 
@@ -60,46 +56,43 @@ let ``Get asset by missing id is Error`` () = task {
     test <@ err.Code = 400 @>
     test <@ err.Message.Contains "violations" @>
     test <@ not (isNull err.RequestId) @>
-}
 
 [<Fact>]
-let ``Get asset by ids is Ok`` () = task {
+let ``Get asset by ids is Ok`` () =
     // Arrange
     let assetIds =
         [ 130452390632424L; 126847700303897L; 124419735577853L ]
 
     // Act
-    let! res = readClient.Assets.RetrieveAsync assetIds
+    let res = readClient.Assets.Retrieve assetIds
 
     let len = Seq.length res
 
     // Assert
     test <@ len = 3 @>
-}
 
 [<Fact>]
-let ``Filter assets is Ok`` () = task {
+let ``Filter assets is Ok`` () =
     // Arrange
     let filter = AssetFilter(RootIds = [ Identity.Create(6687602007296940L) ])
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = readClient.Assets.ListAsync query
+    let res = readClient.Assets.List query
 
     let len = Seq.length res.Items
 
     // Assert
     test <@ len = 10 @>
-}
 
 [<Fact>]
-let ``Filter assets on Name is Ok`` () = task {
+let ``Filter assets on Name is Ok`` () =
     // Arrange
     let filter = AssetFilter(Name = "23-TE-96116-04")
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = readClient.Assets.ListAsync query
+    let res = readClient.Assets.List query
 
     let len = Seq.length res.Items
     let identity = (Seq.head res.Items).Id
@@ -107,16 +100,15 @@ let ``Filter assets on Name is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ identity = 702630644612L @>
-}
 
 [<Fact>]
-let ``Filter assets on ExternalIdPrefix is Ok`` () = task {
+let ``Filter assets on ExternalIdPrefix is Ok`` () =
     // Arrange
     let filter = AssetFilter(ExternalIdPrefix = "odata")
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Assets.ListAsync query
+    let res = writeClient.Assets.List query
 
     let len = Seq.length res.Items
 
@@ -127,17 +119,16 @@ let ``Filter assets on ExternalIdPrefix is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun (e: string) -> e.StartsWith "odata") externalids @>
-}
 
 [<Fact>]
-let ``Filter assets on MetaData is Ok`` () = task {
+let ``Filter assets on MetaData is Ok`` () =
     // Arrange
     let meta = Dictionary (dict [("RES_ID", "525283")])
     let filter = AssetFilter(Metadata = meta)
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = readClient.Assets.ListAsync query
+    let res = readClient.Assets.List query
 
     let len = Seq.length res.Items
     let ms = Seq.map (fun (dto: Asset) -> dto.Metadata) res.Items
@@ -145,16 +136,15 @@ let ``Filter assets on MetaData is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ ms |> Seq.forall (fun (m: Dictionary<string, string>) -> (m.Item "RES_ID") = "525283") @>
-}
 
 [<Fact>]
-let ``Filter assets on ParentIds is Ok`` () = task {
+let ``Filter assets on ParentIds is Ok`` () =
     // Arrange
     let filter = AssetFilter(ParentIds = [3117826349444493L])
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = readClient.Assets.ListAsync query
+    let res = readClient.Assets.List query
 
     let len = Seq.length res.Items
 
@@ -165,31 +155,29 @@ let ``Filter assets on ParentIds is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ parentIds |> Seq.forall (fun e -> e = Nullable 3117826349444493L) @>
-}
 
 [<Fact>]
-let ``Filter assets on Root is Ok`` () = task {
+let ``Filter assets on Root is Ok`` () =
     // Arrange
     let filter = AssetFilter(Root = Nullable true)
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = readClient.Assets.ListAsync query
+    let res = readClient.Assets.List query
 
     // Assert
     test <@ (res.Items |> Seq.length) > 0 @>
     for item in res.Items do
         test <@ item.RootId = item.Id @>
-}
 
 [<Fact>]
-let ``Filter assets on RootIds is Ok`` () = task {
+let ``Filter assets on RootIds is Ok`` () =
     // Arrange
     let filter = AssetFilter(RootIds = [Identity 6687602007296940L])
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = readClient.Assets.ListAsync query
+    let res = readClient.Assets.List query
 
     let len = Seq.length res.Items
     let rootIds =
@@ -200,16 +188,15 @@ let ``Filter assets on RootIds is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall (fun (e: int64) -> e = 6687602007296940L) rootIds @>
-}
 
 [<Fact>]
-let ``Filter assets on Source is Ok`` () = task {
+let ``Filter assets on Source is Ok`` () =
     // Arrange
     let filter = AssetFilter(Source = "cillum irure ex cupidatat dolore")
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Assets.ListAsync query
+    let res = writeClient.Assets.List query
 
     let len = Seq.length res.Items
     let sources =
@@ -219,45 +206,42 @@ let ``Filter assets on Source is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun (e: string) -> e = "cillum irure ex cupidatat dolore") sources @>
-}
 
 [<Fact>]
-let ``Count assets with filter is ok`` () = task {
+let ``Count assets with filter is ok`` () =
     // Arrange
     let meta = Dictionary (dict [("RES_ID", "525283")])
     let filter = AssetFilter(Metadata = meta)
     let query = AssetQuery(Filter = filter)
 
     // Act
-    let! count = readClient.Assets.AggregateAsync query
+    let count = readClient.Assets.Aggregate query
 
     // Assert
     test <@ count > 0 @>
-}
 
 [<Fact>]
-let ``Search assets is Ok`` () = task {
+let ``Search assets is Ok`` () =
     // Arrange
     let search = Search(Name = "23")
     let query = AssetSearch(Limit = Nullable 10, Search = search)
 
     // Act
-    let! res = readClient.Assets.SearchAsync query
+    let res = readClient.Assets.Search query
     let len = Seq.length res
 
     // Assert
     test <@ len = 10 @>
-}
 
 [<Fact>]
-let ``Search assets on CreatedTime Ok`` () = task {
+let ``Search assets on CreatedTime Ok`` () =
     // Arrange
     let timerange = TimeRange(Min = Nullable 1567084348460L, Max = Nullable 1567084348480L)
     let filter = AssetFilter(CreatedTime = timerange)
     let query = AssetSearch(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Assets.SearchAsync query
+    let res = writeClient.Assets.Search query
 
     let len = Seq.length res
     let createdTime = (Seq.head res).CreatedTime
@@ -265,10 +249,9 @@ let ``Search assets on CreatedTime Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ createdTime = 1567084348470L @>
-}
 
 [<Fact>]
-let ``Search assets on LastUpdatedTime Ok`` () = task {
+let ``Search assets on LastUpdatedTime Ok`` () =
 
     // Arrange
     let timerange = TimeRange(Min = Nullable 1567084348460L, Max = Nullable 1567084348480L)
@@ -276,7 +259,7 @@ let ``Search assets on LastUpdatedTime Ok`` () = task {
     let query = AssetSearch(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Assets.SearchAsync query
+    let res = writeClient.Assets.Search query
 
     let len = Seq.length res
     let lastUpdatedTime = (Seq.head res).LastUpdatedTime
@@ -284,16 +267,15 @@ let ``Search assets on LastUpdatedTime Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ lastUpdatedTime = 1567084348470L @>
-}
 
 [<Fact>]
-let ``Search assets on Description is Ok`` () = task {
+let ``Search assets on Description is Ok`` () =
     // Arrange
     let search = Search(Description = "1STSTGGEAR THRUST")
     let query = AssetSearch(Limit = Nullable 10, Search = search)
 
     // Act
-    let! res = readClient.Assets.SearchAsync query
+    let res = readClient.Assets.Search query
 
     let len = Seq.length res
     let descriptions =
@@ -303,16 +285,15 @@ let ``Search assets on Description is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall (fun (e: string) -> e.Contains("1STSTGGEAR THRUST")) descriptions @>
-}
 
 [<Fact>]
-let ``Search assets on Name is Ok`` () = task {
+let ``Search assets on Name is Ok`` () =
     // Arrange
     let search = Search(Name = "TE-96116")
     let query = AssetSearch(Limit = Nullable 10, Search = search)
 
     // Act
-    let! res = readClient.Assets.SearchAsync query
+    let res = readClient.Assets.Search query
 
     let len = Seq.length res
     let names =
@@ -322,27 +303,25 @@ let ``Search assets on Name is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall (fun (e: string) -> e.Contains("96116") || e.Contains("TE")) names @>
-}
 
 [<Fact>]
-let ``Create and delete assets is Ok`` () = task {
+let ``Create and delete assets is Ok`` () =
     // Arrange
     let externalIdString = Guid.NewGuid().ToString();
     let dto = AssetCreate(ExternalId = externalIdString, Name = "Create Assets sdk test")
     let externalId = Identity externalIdString
 
     // Act
-    let! res = writeClient.Assets.CreateAsync [ dto ]
-    let! delRes = writeClient.Assets.DeleteAsync [ externalId ]
+    let res = writeClient.Assets.Create [ dto ]
+    let delRes = writeClient.Assets.Delete [ externalId ]
 
     let resExternalId = (Seq.head res).ExternalId
 
     // Assert
     test <@ resExternalId = externalIdString @>
-}
 
 [<Fact>]
-let ``Update assets is Ok`` () = task {
+let ``Update assets is Ok`` () =
     // Arrange
     let externalIdString = Guid.NewGuid().ToString();
     let newMetadata = Dictionary(dict [
@@ -377,10 +356,10 @@ let ``Update assets is Ok`` () = task {
     }
 
     // Act
-    let! createRes = writeClient.Assets.CreateAsync [ dto ]
-    let! updateRes = writeClient.Assets.UpdateAsync update
+    let createRes = writeClient.Assets.Create [ dto ]
+    let updateRes = writeClient.Assets.Update update
 
-    let! assetsResponses = writeClient.Assets.RetrieveAsync [ newExternalId ]
+    let assetsResponses = writeClient.Assets.Retrieve [ newExternalId ]
 
     let resName, resExternalId, resMetaData =
         let h = Seq.tryHead assetsResponses
@@ -402,8 +381,8 @@ let ``Update assets is Ok`` () = task {
     let newDescription = "updatedDescription"
     let newSource = "updatedSource"
 
-    let! updateRes2 =
-        writeClient.Assets.UpdateAsync [
+    let updateRes2 =
+        writeClient.Assets.Update [
             AssetUpdateItem(
                 externalId=newExternalId,
                 Update=AssetUpdate(
@@ -414,7 +393,7 @@ let ``Update assets is Ok`` () = task {
             )
         ]
 
-    let! assetsResponses = writeClient.Assets.RetrieveAsync [ newExternalId ]
+    let assetsResponses = writeClient.Assets.Retrieve [ newExternalId ]
 
     let resDescription, resSource, resMetaData2, identity =
         let h = Seq.tryHead assetsResponses
@@ -428,8 +407,8 @@ let ``Update assets is Ok`` () = task {
     test <@ resSource = newSource @>
     test <@ resMetaData2.["newKey"] = "newValue" @>
 
-    let! updateRes3 =
-        writeClient.Assets.UpdateAsync [
+    let updateRes3 =
+        writeClient.Assets.Update [
             AssetUpdateItem(
                 id = identity,
                 Update = AssetUpdate(
@@ -440,8 +419,8 @@ let ``Update assets is Ok`` () = task {
             )
         ]
 
-    let! assetsResponses = writeClient.Assets.RetrieveAsync [ identity ]
-    let! delRes = writeClient.Assets.DeleteAsync [ identity]
+    let assetsResponses = writeClient.Assets.Retrieve [ identity ]
+    let delRes = writeClient.Assets.Delete [ identity]
 
     let resExternalId2, resSource2, resMetaData3 =
         let h = Seq.tryHead assetsResponses
@@ -454,11 +433,10 @@ let ``Update assets is Ok`` () = task {
     test <@ isNull resExternalId2 @>
     test <@ isNull resSource2 @>
     test <@ resMetaData3.Count = 0 @>
-}
 
 /// Playground
 [<Fact>]
-let ``Filter assets on single Label is Ok`` () = task {
+let ``Filter assets on single Label is Ok`` () =
     // Arrange
     let labels = LabelFilter.All("AssetTestLabel1")
 
@@ -466,7 +444,7 @@ let ``Filter assets on single Label is Ok`` () = task {
     let query = AssetQuery(Limit = Nullable 1000, Filter = filter)
 
     // Act
-    let! res = writeClient.Playground.Assets.ListAsync query
+    let res = writeClient.Assets.List query
 
     let allItemsMatch =
         res.Items |> Seq.map (fun item ->
@@ -479,11 +457,10 @@ let ``Filter assets on single Label is Ok`` () = task {
     // Test may fail if datastudio playground data changes
     test <@ (res.Items |> Seq.length) > 0 @>
     test <@ allItemsMatch @>
-}
 
 
 [<Fact>]
-let ``Filter assets on Label and metadata is Ok`` () = task {
+let ``Filter assets on Label and metadata is Ok`` () =
     // Arrange
     let labels = LabelFilter.All("AssetTestLabel1")
 
@@ -497,7 +474,7 @@ let ``Filter assets on Label and metadata is Ok`` () = task {
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Playground.Assets.ListAsync query
+    let res = writeClient.Assets.List query
 
     // Assert
     let validateItem (item:Asset) =
@@ -516,10 +493,9 @@ let ``Filter assets on Label and metadata is Ok`` () = task {
 
     test <@ (Seq.length res.Items) > 0 @>
     test <@ allItemsMatch @>
-}
 
 [<Fact>]
-let ``Filter assets with labels AND filter is Ok`` () = task{
+let ``Filter assets with labels AND filter is Ok`` () =
     // Arrange
     let labels = LabelFilter.All (seq [ "AssetTestLabel1"; "AssetTestLabel2" ])
 
@@ -530,7 +506,7 @@ let ``Filter assets with labels AND filter is Ok`` () = task{
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Playground.Assets.ListAsync query
+    let res = writeClient.Assets.List query
 
     // Assert
     let resLabels =
@@ -545,7 +521,6 @@ let ``Filter assets with labels AND filter is Ok`` () = task{
             )
     test <@ ( res.Items |> Seq.length ) > 0 @>
     test <@ itemsMatch |> Seq.forall id @>
-}
 
 [<Fact>]
 let ``Filter assets on metadata and two labels with OR filter is Ok`` () = task {

--- a/CogniteSdk/test/fsharp/Assets.fs
+++ b/CogniteSdk/test/fsharp/Assets.fs
@@ -12,51 +12,54 @@ open CogniteSdk
 open Common
 
 [<Fact>]
-let ``List assets with limit is Ok`` () =
+let ``List assets with limit is Ok`` () = task {
     // Arrange
     let query = AssetQuery(Limit= Nullable 10)
 
     // Act
-    let res = readClient.Assets.List(query)
+    let! res = readClient.Assets.ListAsync(query)
     let len = Seq.length res.Items
 
     // Assert
     test <@ len = 10 @>
+}
 
 [<Fact>]
-let ``Get asset by id is Ok`` () =
+let ``Get asset by id is Ok`` () = task {
     // Arrange
     let assetId = 130452390632424L
 
     // Act
-    let res = readClient.Assets.Get assetId
+    let! res = readClient.Assets.GetAsync assetId
 
     let resId = res.Id
 
     // Assert
     test <@ resId = assetId @>
+}
 
 [<Fact>]
-let ``Get asset with metadata is Ok`` () =
+let ``Get asset with metadata is Ok`` () = task {
     // Arrange
     let assetId = 130452390632424L
 
     // Act
-    let res = readClient.Assets.Get assetId
+    let! res = readClient.Assets.GetAsync assetId
 
     let md = res.Metadata
 
     // Assert
     test <@ not (isNull md) @>
     test <@ md.["SOURCE_DB"] = "workmate" @>
+}
 
 [<Fact>]
-let ``Get asset without metadata is Ok`` () =
+let ``Get asset without metadata is Ok`` () = task {
     // Arrange
     let assetId = 130452390632424L
 
     // Act
-    let res = readClient.Assets.Get<AssetWithoutMetadata> assetId
+    let! res = readClient.Assets.GetAsync<AssetWithoutMetadata> assetId
 
     let resId = res.Id
 
@@ -65,20 +68,21 @@ let ``Get asset without metadata is Ok`` () =
 
     // Assert
     test <@ isNull md @>
+}
 
 [<Fact>]
-let ``Get asset by missing id is Error`` () =
+let ``Get asset by missing id is Error`` () = task {
     // Arrange
     let assetId = 0L
 
     // Act
-    let res =
+    let! res = task {
         try
-            let a = readClient.Assets.Get assetId
-            Ok a
+            let! a = readClient.Assets.GetAsync assetId
+            return Ok a
         with
-        | :? ResponseException as e -> Error e
-
+        | :? ResponseException as e -> return Error e
+    }
     let err = Result.getError res
 
     // Assert
@@ -86,34 +90,37 @@ let ``Get asset by missing id is Error`` () =
     test <@ err.Code = 400 @>
     test <@ err.Message.Contains "violations" @>
     test <@ not (isNull err.RequestId) @>
+}
 
 [<Fact>]
-let ``Get asset by ids is Ok`` () =
+let ``Get asset by ids is Ok`` () = task {
     // Arrange
     let assetIds =
         [ 130452390632424L; 126847700303897L; 124419735577853L ]
 
     // Act
-    let res = readClient.Assets.Retrieve assetIds
+    let! res = readClient.Assets.RetrieveAsync assetIds
 
     let len = Seq.length res
 
     // Assert
     test <@ len = 3 @>
+}
 
 [<Fact>]
-let ``Filter assets is Ok`` () =
+let ``Filter assets is Ok`` () = task {
     // Arrange
     let filter = AssetFilter(RootIds = [ Identity.Create(6687602007296940L) ])
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = readClient.Assets.List query
+    let! res = readClient.Assets.ListAsync query
 
     let len = Seq.length res.Items
 
     // Assert
     test <@ len = 10 @>
+}
 
 [<Fact>]
 let ``Filter assets on Name is Ok`` () =
@@ -168,13 +175,13 @@ let ``Filter assets on MetaData is Ok`` () =
     test <@ ms |> Seq.forall (fun (m: Dictionary<string, string>) -> (m.Item "RES_ID") = "525283") @>
 
 [<Fact>]
-let ``Filter assets on ParentIds is Ok`` () =
+let ``Filter assets on ParentIds is Ok`` () = task {
     // Arrange
     let filter = AssetFilter(ParentIds = [3117826349444493L])
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = readClient.Assets.List query
+    let! res = readClient.Assets.ListAsync query
 
     let len = Seq.length res.Items
 
@@ -185,29 +192,31 @@ let ``Filter assets on ParentIds is Ok`` () =
     // Assert
     test <@ len = 10 @>
     test <@ parentIds |> Seq.forall (fun e -> e = Nullable 3117826349444493L) @>
+}
 
 [<Fact>]
-let ``Filter assets on Root is Ok`` () =
+let ``Filter assets on Root is Ok`` () = task {
     // Arrange
     let filter = AssetFilter(Root = Nullable true)
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = readClient.Assets.List query
+    let! res = readClient.Assets.ListAsync query
 
     // Assert
     test <@ (res.Items |> Seq.length) > 0 @>
     for item in res.Items do
         test <@ item.RootId = item.Id @>
+}
 
 [<Fact>]
-let ``Filter assets on RootIds is Ok`` () =
+let ``Filter assets on RootIds is Ok`` () = task {
     // Arrange
     let filter = AssetFilter(RootIds = [Identity 6687602007296940L])
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = readClient.Assets.List query
+    let! res = readClient.Assets.ListAsync query
 
     let len = Seq.length res.Items
     let rootIds =
@@ -218,15 +227,16 @@ let ``Filter assets on RootIds is Ok`` () =
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall (fun (e: int64) -> e = 6687602007296940L) rootIds @>
+}
 
 [<Fact>]
-let ``Filter assets on Source is Ok`` () =
+let ``Filter assets on Source is Ok`` () = task {
     // Arrange
     let filter = AssetFilter(Source = "cillum irure ex cupidatat dolore")
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = writeClient.Assets.List query
+    let! res = writeClient.Assets.ListAsync query
 
     let len = Seq.length res.Items
     let sources =
@@ -236,42 +246,45 @@ let ``Filter assets on Source is Ok`` () =
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun (e: string) -> e = "cillum irure ex cupidatat dolore") sources @>
+}
 
 [<Fact>]
-let ``Count assets with filter is ok`` () =
+let ``Count assets with filter is ok`` () = task {
     // Arrange
     let meta = Dictionary (dict [("RES_ID", "525283")])
     let filter = AssetFilter(Metadata = meta)
     let query = AssetQuery(Filter = filter)
 
     // Act
-    let count = readClient.Assets.Aggregate query
+    let! count = readClient.Assets.AggregateAsync query
 
     // Assert
     test <@ count > 0 @>
+}
 
 [<Fact>]
-let ``Search assets is Ok`` () =
+let ``Search assets is Ok`` () = task {
     // Arrange
     let search = Search(Name = "23")
     let query = AssetSearch(Limit = Nullable 10, Search = search)
 
     // Act
-    let res = readClient.Assets.Search query
+    let! res = readClient.Assets.SearchAsync query
     let len = Seq.length res
 
     // Assert
     test <@ len = 10 @>
+}
 
 [<Fact>]
-let ``Search assets on CreatedTime Ok`` () =
+let ``Search assets on CreatedTime Ok`` () = task {
     // Arrange
     let timerange = TimeRange(Min = Nullable 1567084348460L, Max = Nullable 1567084348480L)
     let filter = AssetFilter(CreatedTime = timerange)
     let query = AssetSearch(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = writeClient.Assets.Search query
+    let! res = writeClient.Assets.SearchAsync query
 
     let len = Seq.length res
     let createdTime = (Seq.head res).CreatedTime
@@ -279,9 +292,10 @@ let ``Search assets on CreatedTime Ok`` () =
     // Assert
     test <@ len = 1 @>
     test <@ createdTime = 1567084348470L @>
+}
 
 [<Fact>]
-let ``Search assets on LastUpdatedTime Ok`` () =
+let ``Search assets on LastUpdatedTime Ok`` () = task {
 
     // Arrange
     let timerange = TimeRange(Min = Nullable 1567084348460L, Max = Nullable 1567084348480L)
@@ -289,7 +303,7 @@ let ``Search assets on LastUpdatedTime Ok`` () =
     let query = AssetSearch(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = writeClient.Assets.Search query
+    let! res = writeClient.Assets.SearchAsync query
 
     let len = Seq.length res
     let lastUpdatedTime = (Seq.head res).LastUpdatedTime
@@ -297,15 +311,16 @@ let ``Search assets on LastUpdatedTime Ok`` () =
     // Assert
     test <@ len = 1 @>
     test <@ lastUpdatedTime = 1567084348470L @>
+}
 
 [<Fact>]
-let ``Search assets on Description is Ok`` () =
+let ``Search assets on Description is Ok`` () = task {
     // Arrange
     let search = Search(Description = "1STSTGGEAR THRUST")
     let query = AssetSearch(Limit = Nullable 10, Search = search)
 
     // Act
-    let res = readClient.Assets.Search query
+    let! res = readClient.Assets.SearchAsync query
 
     let len = Seq.length res
     let descriptions =
@@ -315,15 +330,16 @@ let ``Search assets on Description is Ok`` () =
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall (fun (e: string) -> e.Contains("1STSTGGEAR THRUST")) descriptions @>
+}
 
 [<Fact>]
-let ``Search assets on Name is Ok`` () =
+let ``Search assets on Name is Ok`` () = task {
     // Arrange
     let search = Search(Name = "TE-96116")
     let query = AssetSearch(Limit = Nullable 10, Search = search)
 
     // Act
-    let res = readClient.Assets.Search query
+    let! res = readClient.Assets.SearchAsync query
 
     let len = Seq.length res
     let names =
@@ -333,25 +349,27 @@ let ``Search assets on Name is Ok`` () =
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall (fun (e: string) -> e.Contains("96116") || e.Contains("TE")) names @>
+}
 
 [<Fact>]
-let ``Create and delete assets is Ok`` () =
+let ``Create and delete assets is Ok`` () = task {
     // Arrange
     let externalIdString = Guid.NewGuid().ToString();
     let dto = AssetCreate(ExternalId = externalIdString, Name = "Create Assets sdk test")
     let externalId = Identity externalIdString
 
     // Act
-    let res = writeClient.Assets.Create [ dto ]
-    let delRes = writeClient.Assets.Delete [ externalId ]
+    let! res = writeClient.Assets.CreateAsync [ dto ]
+    let! delRes = writeClient.Assets.DeleteAsync [ externalId ]
 
     let resExternalId = (Seq.head res).ExternalId
 
     // Assert
     test <@ resExternalId = externalIdString @>
+}
 
 [<Fact>]
-let ``Update assets is Ok`` () =
+let ``Update assets is Ok`` () = task {
     // Arrange
     let externalIdString = Guid.NewGuid().ToString();
     let newMetadata = Dictionary(dict [
@@ -411,8 +429,8 @@ let ``Update assets is Ok`` () =
     let newDescription = "updatedDescription"
     let newSource = "updatedSource"
 
-    let updateRes2 =
-        writeClient.Assets.Update [
+    let! updateRes2 =
+        writeClient.Assets.UpdateAsync [
             AssetUpdateItem(
                 externalId=newExternalId,
                 Update=AssetUpdate(
@@ -423,7 +441,7 @@ let ``Update assets is Ok`` () =
             )
         ]
 
-    let assetsResponses = writeClient.Assets.Retrieve [ newExternalId ]
+    let! assetsResponses = writeClient.Assets.RetrieveAsync [ newExternalId ]
 
     let resDescription, resSource, resMetaData2, identity =
         let h = Seq.tryHead assetsResponses
@@ -437,8 +455,8 @@ let ``Update assets is Ok`` () =
     test <@ resSource = newSource @>
     test <@ resMetaData2.["newKey"] = "newValue" @>
 
-    let updateRes3 =
-        writeClient.Assets.Update [
+    let! updateRes3 =
+        writeClient.Assets.UpdateAsync [
             AssetUpdateItem(
                 id = identity,
                 Update = AssetUpdate(
@@ -449,8 +467,8 @@ let ``Update assets is Ok`` () =
             )
         ]
 
-    let assetsResponses = writeClient.Assets.Retrieve [ identity ]
-    let delRes = writeClient.Assets.Delete [ identity]
+    let! assetsResponses = writeClient.Assets.RetrieveAsync [ identity ]
+    let! delRes = writeClient.Assets.DeleteAsync [ identity]
 
     let resExternalId2, resSource2, resMetaData3 =
         let h = Seq.tryHead assetsResponses
@@ -463,10 +481,11 @@ let ``Update assets is Ok`` () =
     test <@ isNull resExternalId2 @>
     test <@ isNull resSource2 @>
     test <@ resMetaData3.Count = 0 @>
+}
 
 /// Playground
 [<Fact>]
-let ``Filter assets on single Label is Ok`` () =
+let ``Filter assets on single Label is Ok`` () = task {
     // Arrange
     let labels = LabelFilter.All("AssetTestLabel1")
 
@@ -487,10 +506,10 @@ let ``Filter assets on single Label is Ok`` () =
     // Test may fail if datastudio playground data changes
     test <@ (res.Items |> Seq.length) > 0 @>
     test <@ allItemsMatch @>
-
+}
 
 [<Fact>]
-let ``Filter assets on Label and metadata is Ok`` () =
+let ``Filter assets on Label and metadata is Ok`` () = task {
     // Arrange
     let labels = LabelFilter.All("AssetTestLabel1")
 
@@ -504,7 +523,7 @@ let ``Filter assets on Label and metadata is Ok`` () =
     let query = AssetQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let res = writeClient.Assets.List query
+    let! res = writeClient.Assets.ListAsync query
 
     // Assert
     let validateItem (item:Asset) =
@@ -523,9 +542,10 @@ let ``Filter assets on Label and metadata is Ok`` () =
 
     test <@ (Seq.length res.Items) > 0 @>
     test <@ allItemsMatch @>
+}
 
 [<Fact>]
-let ``Filter assets with labels AND filter is Ok`` () =
+let ``Filter assets with labels AND filter is Ok`` () = task {
     // Arrange
     let labels = LabelFilter.All (seq [ "AssetTestLabel1"; "AssetTestLabel2" ])
 
@@ -551,6 +571,7 @@ let ``Filter assets with labels AND filter is Ok`` () =
             )
     test <@ ( res.Items |> Seq.length ) > 0 @>
     test <@ itemsMatch |> Seq.forall id @>
+}
 
 [<Fact>]
 let ``Filter assets on metadata and two labels with OR filter is Ok`` () = task {

--- a/CogniteSdk/test/fsharp/Common.fs
+++ b/CogniteSdk/test/fsharp/Common.fs
@@ -6,7 +6,7 @@ open System.Net.Http
 open CogniteSdk
 
 module Common =
-    let createClient apiKey project url includeMetadata =
+    let createClient apiKey project url =
         let handler = new HttpClientHandler(ServerCertificateCustomValidationCallback = (fun message cert chain errors -> true))
         let httpClient = new HttpClient(handler);
 
@@ -23,14 +23,12 @@ module Common =
             (Environment.GetEnvironmentVariable "TEST_API_KEY_READ")
             "publicdata"
             "https://api.cognitedata.com"
-            true
 
     let writeClient =
         createClient
             (Environment.GetEnvironmentVariable "TEST_API_KEY_WRITE")
             "fusiondotnet-tests"
             "https://greenfield.cognitedata.com"
-            true
 
     let noAuthClient =
         let handler = new HttpClientHandler(ServerCertificateCustomValidationCallback = (fun message cert chain errors -> true))

--- a/CogniteSdk/test/fsharp/Common.fs
+++ b/CogniteSdk/test/fsharp/Common.fs
@@ -15,7 +15,6 @@ module Common =
             .AddHeader("api-key", apiKey)
             .SetProject(project)
             .SetBaseUrl(Uri(url))
-            .IncludeMetadata(includeMetadata)
             .Build();
 
 
@@ -25,13 +24,6 @@ module Common =
             "publicdata"
             "https://api.cognitedata.com"
             true
-
-    let readClientWithoutMetadata =
-        createClient
-            (Environment.GetEnvironmentVariable "TEST_API_KEY_READ")
-            "publicdata"
-            "https://api.cognitedata.com"
-            false
 
     let writeClient =
         createClient

--- a/CogniteSdk/test/fsharp/Common.fs
+++ b/CogniteSdk/test/fsharp/Common.fs
@@ -17,7 +17,6 @@ module Common =
             .SetBaseUrl(Uri(url))
             .Build();
 
-
     let readClient =
         createClient
             (Environment.GetEnvironmentVariable "TEST_API_KEY_READ")

--- a/CogniteSdk/test/fsharp/Common.fs
+++ b/CogniteSdk/test/fsharp/Common.fs
@@ -6,7 +6,7 @@ open System.Net.Http
 open CogniteSdk
 
 module Common =
-    let createClient apiKey project url =
+    let createClient apiKey project url includeMetadata =
         let handler = new HttpClientHandler(ServerCertificateCustomValidationCallback = (fun message cert chain errors -> true))
         let httpClient = new HttpClient(handler);
 
@@ -15,19 +15,30 @@ module Common =
             .AddHeader("api-key", apiKey)
             .SetProject(project)
             .SetBaseUrl(Uri(url))
+            .IncludeMetadata(includeMetadata)
             .Build();
+
 
     let readClient =
         createClient
             (Environment.GetEnvironmentVariable "TEST_API_KEY_READ")
             "publicdata"
             "https://api.cognitedata.com"
+            true
+
+    let readClientWithoutMetadata =
+        createClient
+            (Environment.GetEnvironmentVariable "TEST_API_KEY_READ")
+            "publicdata"
+            "https://api.cognitedata.com"
+            false
 
     let writeClient =
         createClient
             (Environment.GetEnvironmentVariable "TEST_API_KEY_WRITE")
             "fusiondotnet-tests"
             "https://greenfield.cognitedata.com"
+            true
 
     let noAuthClient =
         let handler = new HttpClientHandler(ServerCertificateCustomValidationCallback = (fun message cert chain errors -> true))

--- a/CogniteSdk/test/fsharp/Events.fs
+++ b/CogniteSdk/test/fsharp/Events.fs
@@ -87,6 +87,38 @@ let ``Get event by ids is Ok`` () = task {
 }
 
 [<Fact>]
+let ``Get event with metadata is Ok`` () = task {
+    // Arrange
+    let eventId = 1995162693488L
+
+    // Act
+    let! res = readClient.Events.GetAsync eventId
+
+    let md = res.Metadata
+
+    // Assert
+    test <@ not (isNull md) @>
+    test <@ md.["source"] = "akerbp-cdp" @>
+}
+
+[<Fact>]
+let ``Get event without metadata is Ok`` () = task {
+    // Arrange
+    let eventId = 1995162693488L
+
+    // Act
+    let! res = readClient.Events.GetAsync<EventWithoutMetadata> eventId
+
+    let resId = res.Id
+
+    // Assert
+    let md = res.Metadata
+
+    // Assert
+    test <@ isNull md @>
+}
+
+[<Fact>]
 let ``Update events is Ok`` () = task {
     // Arrange
     let externalId = Guid.NewGuid().ToString();

--- a/CogniteSdk/test/fsharp/Events.fs
+++ b/CogniteSdk/test/fsharp/Events.fs
@@ -130,27 +130,26 @@ let ``Update events is Ok`` () =
     test <@ getDto.Metadata |> fun a -> metaDataOk @>
 
 [<Fact>]
-let ``List events with limit is Ok`` () = task {
+let ``List events with limit is Ok`` () =
     // Arrange
     let query = EventQuery(Limit = Nullable 10)
 
     // Act
-    let! res = readClient.Events.ListAsync query
+    let res = readClient.Events.List query
 
     let len = Seq.length res.Items
 
     // Assert
     test <@ len = 10 @>
-}
 
 [<Fact>]
-let ``Filter events on AssetIds is Ok`` () = task {
+let ``Filter events on AssetIds is Ok`` () =
     // Arrange
     let filter = EventFilter(AssetIds = [ 4650652196144007L ])
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = readClient.Events.ListAsync query
+    let res = readClient.Events.List query
 
     let len = Seq.length res.Items
     let assetIds = Seq.collect (fun (e: Event) -> e.AssetIds) res.Items
@@ -158,16 +157,15 @@ let ``Filter events on AssetIds is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall ((=) 4650652196144007L) assetIds @>
-}
 
 [<Fact>]
-let ``Filter events on subtype is Ok`` () = task {
+let ``Filter events on subtype is Ok`` () =
     // Arrange
     let filter = EventFilter(Subtype = "VAL")
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = readClient.Events.ListAsync query
+    let res = readClient.Events.List query
 
     let len = Seq.length res.Items
 
@@ -176,17 +174,16 @@ let ``Filter events on subtype is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ subTypes |> Seq.forall ((=) "VAL") @>
-}
 
 [<Fact>]
-let ``Filter events on CreatedTime is Ok`` () = task {
+let ``Filter events on CreatedTime is Ok`` () =
     // Arrange
     let timerange = TimeRange(Min = Nullable 1582975736270L, Max = Nullable 1582975736290L)
     let filter = EventFilter(CreatedTime = timerange)
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Events.ListAsync query
+    let res = writeClient.Events.List query
 
     let len = Seq.length res.Items
 
@@ -195,17 +192,16 @@ let ``Filter events on CreatedTime is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun t -> t < 1582975736290L && t > 1582975736270L) createdTimes @>
-}
 
 [<Fact>]
-let ``Filter events on LastUpdatedTime is Ok`` () = task {
+let ``Filter events on LastUpdatedTime is Ok`` () =
     // Arrange
     let timerange = TimeRange(Min = Nullable 1582975736270L, Max = Nullable 1582975736290L)
     let filter = EventFilter(LastUpdatedTime = timerange)
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Events.ListAsync query
+    let res = writeClient.Events.List query
     let len = Seq.length res.Items
 
     let lastUpdatedTimes = Seq.map (fun (e: Event) -> e.CreatedTime) res.Items
@@ -213,17 +209,16 @@ let ``Filter events on LastUpdatedTime is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun t -> t < 1582975736290L && t > 1582975736270L) lastUpdatedTimes @>
-}
 
 [<Fact>]
-let ``Filter events on StartTime is Ok`` () = task {
+let ``Filter events on StartTime is Ok`` () =
     // Arrange
     let timerange = TimeRange(Min = Nullable 1565941319000L, Max = Nullable 1565941339000L)
     let filter = EventFilter(StartTime = timerange)
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Events.ListAsync query
+    let res = writeClient.Events.List query
 
     let len = Seq.length res.Items
 
@@ -232,17 +227,16 @@ let ``Filter events on StartTime is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun (t: Nullable<int64>) -> t.Value < 1565941339000L && t.Value > 1565941319000L) startTimes @>
-}
 
 [<Fact>]
-let ``Filter events on EndTime is Ok`` () = task {
+let ``Filter events on EndTime is Ok`` () =
     // Arrange
     let timerange = TimeRange(Min = Nullable 1565941331000L, Max = Nullable 1565941351000L)
     let filter = EventFilter(EndTime = timerange)
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Events.ListAsync query
+    let res = writeClient.Events.List query
     let len = Seq.length res.Items
 
     let endTimes = Seq.map (fun (e: Event) -> e.EndTime) res.Items
@@ -250,32 +244,30 @@ let ``Filter events on EndTime is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun (t: Nullable<int64>) -> t.Value < 1565941351000L && t.Value > 1565941331000L) endTimes @>
-}
 
 [<Fact>]
-let ``Filter events on ExternalIdPrefix is Ok`` () = task {
+let ``Filter events on ExternalIdPrefix is Ok`` () =
     // Arrange
     let filter = EventFilter(ExternalIdPrefix = "odata")
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Events.ListAsync query
+    let res = writeClient.Events.List query
 
     let externalIds = Seq.map (fun (e: Event) -> e.ExternalId) res.Items
 
     // Assert
     test <@ Seq.length externalIds > 0 @>
     test <@ Seq.forall (fun (e: string) -> e.StartsWith("odata")) externalIds @>
-}
 
 [<Fact>]
-let ``Filter events on Metadata is Ok`` () = task {
+let ``Filter events on Metadata is Ok`` () =
     // Arrange
     let filter = EventFilter(Metadata = Dictionary(dict ["sourceId", "2758173488388242"]))
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = writeClient.Events.ListAsync query
+    let res = writeClient.Events.List query
     let len = Seq.length res.Items
 
     let ms = Seq.map (fun (e: Event) -> e.Metadata) res.Items
@@ -283,16 +275,15 @@ let ``Filter events on Metadata is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall (fun (m: Dictionary<string, string>) -> m.Item "sourceId" = "2758173488388242") ms @>
-}
 
 [<Fact>]
-let ``Filter events on Source is Ok`` () = task {
+let ``Filter events on Source is Ok`` () =
     // Arrange
     let filter = EventFilter(Source = "akerbp-cdp")
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
 
     // Act
-    let! res = readClient.Events.ListAsync query
+    let res = readClient.Events.List query
     let len = Seq.length res.Items
 
     let sources = Seq.map (fun (e: Event) -> e.Source) res.Items
@@ -300,15 +291,14 @@ let ``Filter events on Source is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall ((=) "akerbp-cdp") sources @>
-}
 
 [<Fact>]
-let ``Filter events on Type is Ok`` () = task {
+let ``Filter events on Type is Ok`` () =
     // Arrange
     let filter = EventFilter(Type = "Monad")
     let query = EventQuery(Limit = Nullable 10, Filter = filter)
     // Act
-    let! res = writeClient.Events.ListAsync query
+    let res = writeClient.Events.List query
     let len = Seq.length res.Items
 
     let types = Seq.map (fun (e: Event) -> e.Type) res.Items
@@ -316,33 +306,29 @@ let ``Filter events on Type is Ok`` () = task {
     // Assert
     test <@ len > 0 @>
     test <@ Seq.forall ((=) "Monad") types @>
-}
 
 [<Fact>]
-let ``Count assets with filter is ok`` () = task {
+let ``Count assets with filter is ok`` () =
     // Arrange
     let meta = Dictionary (dict [("version", "undefined")])
     let filter = EventFilter(Metadata = meta)
     let query = EventQuery(Filter = filter)
 
     // Act
-    let! count = readClient.Events.AggregateAsync query
+    let count = readClient.Events.Aggregate query
 
     // Assert
     test <@ count > 0 @>
-}
-
 
 [<Fact>]
-let ``Search events is Ok`` () = task {
+let ``Search events is Ok`` () =
     // Arrange
     let dto = DescriptionSearch(Description = "dotnet")
     let query = EventSearch(Search = dto)
 
     // Act
-    let! res = writeClient.Events.SearchAsync query
+    let res = writeClient.Events.Search query
     let len = Seq.length res
 
     // Assert
     test <@ len > 0 @>
-}

--- a/CogniteSdk/test/fsharp/Events.fs
+++ b/CogniteSdk/test/fsharp/Events.fs
@@ -34,33 +34,31 @@ let ``Create and delete events is Ok`` () = task {
 }
 
 [<Fact>]
-let ``Get event by id is Ok`` () = task {
+let ``Get event by id is Ok`` () =
     // Arrange
     let eventId = 19442413705355L
 
     // Act
-    let! res = readClient.Events.GetAsync eventId
+    let res = readClient.Events.Get eventId
 
     let resId = res.Id
 
     // Assert
     test <@ resId = eventId @>
-}
+
 
 [<Fact>]
-let ``Get event by missing id is Error`` () = task {
+let ``Get event by missing id is Error`` () =
     // Arrange
     let eventId = 0L
 
     // Act
-    let! res =
-        task {
-            try
-                let! a = readClient.Events.GetAsync eventId
-                return Ok a
-            with
-            | :? ResponseException as e -> return Error e
-        }
+    let res =
+        try
+            let a = readClient.Events.Get eventId
+            Ok a
+        with
+        | :? ResponseException as e -> Error e
 
     let err = Result.getError res
 
@@ -69,25 +67,24 @@ let ``Get event by missing id is Error`` () = task {
     test <@ err.Code = 400 @>
     test <@ err.Message.Contains "constraint violations" @>
     test <@ not (isNull err.RequestId) @>
-}
 
 [<Fact>]
-let ``Get event by ids is Ok`` () = task {
+let ``Get event by ids is Ok`` () =
     // Arrange
     let eventIds =
         [ 1995162693488L; 6959277162251L; 13821390033633L ]
 
     // Act
-    let! res = readClient.Events.RetrieveAsync eventIds
+    let res = readClient.Events.Retrieve eventIds
 
     let len = Seq.length res
 
     // Assert
     test <@ len = 3 @>
-}
+
 
 [<Fact>]
-let ``Update events is Ok`` () = task {
+let ``Update events is Ok`` () =
     // Arrange
     let externalId = Guid.NewGuid().ToString();
     let newMetadata = Dictionary(dict [
@@ -104,9 +101,9 @@ let ``Update events is Ok`` () = task {
         )
     let newDescription = "UpdatedDesc"
     // Act
-    let! createRes = writeClient.Events.CreateAsync [ dto ]
-    let! updateRes =
-        writeClient.Events.UpdateAsync [
+    let createRes = writeClient.Events.Create [ dto ]
+    let updateRes =
+        writeClient.Events.Update [
             EventUpdateItem(
                 externalId = externalId,
                 Update = EventUpdate(
@@ -116,8 +113,8 @@ let ``Update events is Ok`` () = task {
             )
         ]
 
-    let! getRes = writeClient.Events.RetrieveAsync [ externalId ]
-    let! delRes = writeClient.Events.DeleteAsync [ externalId ]
+    let getRes = writeClient.Events.Retrieve [ externalId ]
+    let delRes = writeClient.Events.Delete [ externalId ]
 
     let getDto = Seq.head getRes
 
@@ -131,7 +128,6 @@ let ``Update events is Ok`` () = task {
     test <@ getDto.ExternalId = externalId @>
     test <@ getDto.Description = newDescription @>
     test <@ getDto.Metadata |> fun a -> metaDataOk @>
-}
 
 [<Fact>]
 let ``List events with limit is Ok`` () = task {

--- a/CogniteSdk/test/fsharp/Functions.fs
+++ b/CogniteSdk/test/fsharp/Functions.fs
@@ -79,7 +79,7 @@ let ``Retrieve response from functionCalls is Ok`` () = task {
     test <@ res.Response.ToString() = "42" @>
 }
 
-[<Fact>]
+//[<Fact>]
 let ``Call function is Ok`` () = task {
     // Act
     let! res = writeClient.Playground.FunctionCalls.CallFunction(8287208469954416L, Identity("test"))

--- a/CogniteSdk/test/fsharp/Functions.fs
+++ b/CogniteSdk/test/fsharp/Functions.fs
@@ -79,7 +79,7 @@ let ``Retrieve response from functionCalls is Ok`` () = task {
     test <@ res.Response.ToString() = "42" @>
 }
 
-//[<Fact>]
+[<Fact>]
 let ``Call function is Ok`` () = task {
     // Act
     let! res = writeClient.Playground.FunctionCalls.CallFunction(8287208469954416L, Identity("test"))

--- a/CogniteSdk/test/fsharp/TimeSeries.fs
+++ b/CogniteSdk/test/fsharp/TimeSeries.fs
@@ -12,38 +12,36 @@ open CogniteSdk
 open Common
 
 [<Fact>]
-let ``Get timeseries is Ok`` () = task {
+let ``Get timeseries is Ok`` () =
     // Arrange
     let query = TimeSeriesQuery(Limit = Nullable 10)
 
     // Act
-    let! response = readClient.TimeSeries.ListAsync query
+    let response = readClient.TimeSeries.List query
 
     let len = Seq.length response.Items
 
     // Assert
     test <@ len = 10 @>
-}
 
 [<Fact>]
-let ``Count timeseries is Ok`` () = task {
+let ``Count timeseries is Ok`` () =
     // Arrange
     let query = TimeSeriesQuery(Limit = Nullable 10)
 
     // Act
-    let! count = readClient.TimeSeries.AggregateAsync query
+    let count = readClient.TimeSeries.Aggregate query
 
     // Assert
     test <@ count > 0 @>
-}
 
 [<Fact>]
-let ``Get timeseries by ids is Ok`` () = task {
+let ``Get timeseries by ids is Ok`` () =
     // Arrange
     let id = 6190956317771L
 
     // Act
-    let! dtos = readClient.TimeSeries.RetrieveAsync [ id ]
+    let dtos = readClient.TimeSeries.Retrieve [ id ]
 
     let len = Seq.length dtos
 
@@ -56,20 +54,19 @@ let ``Get timeseries by ids is Ok`` () = task {
     // Assert
     test <@ resId = id @>
     test <@ len > 0 @>
-}
 
 [<Fact>]
-let ``Get timeseries by missing id is Error`` () = task {
+let ``Get timeseries by missing id is Error`` () =
     // Arrange
     let id = Identity 0L
 
     // Act
-    Assert.ThrowsAsync<ArgumentException>(fun () -> readClient.TimeSeries.RetrieveAsync [ id ] :> _)
+    Assert.Throws<ResponseException>(fun () -> readClient.TimeSeries.Retrieve [ id ] :> obj)
     |> ignore
-}
+
 
 [<Fact>]
-let ``Create and delete timeseries is Ok`` () = task {
+let ``Create and delete timeseries is Ok`` () =
     // Arrange
     let externalIdString = Guid.NewGuid().ToString();
     let dto =
@@ -81,8 +78,8 @@ let ``Create and delete timeseries is Ok`` () = task {
         )
 
     // Act
-    let! timeSereiesResponses = writeClient.TimeSeries.CreateAsync [ dto ]
-    let! delRes = writeClient.TimeSeries.DeleteAsync [ externalIdString ]
+    let timeSereiesResponses = writeClient.TimeSeries.Create [ dto ]
+    let delRes = writeClient.TimeSeries.Delete [ externalIdString ]
 
     let resExternalId =
         let h = Seq.tryHead timeSereiesResponses
@@ -92,10 +89,9 @@ let ``Create and delete timeseries is Ok`` () = task {
 
     // Assert
     test <@ resExternalId = externalIdString @>
-}
 
 [<Fact>]
-let ``Search timeseries is Ok`` () = task {
+let ``Search timeseries is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSearch(
@@ -104,15 +100,14 @@ let ``Search timeseries is Ok`` () = task {
         )
 
     // Act
-    let! dtos = readClient.TimeSeries.SearchAsync query
+    let dtos = readClient.TimeSeries.Search query
     let len = Seq.length dtos
 
     // Assert
     test <@ len > 0 @>
-}
 
 [<Fact>]
-let ``Search timeseries on CreatedTime Ok`` () = task {
+let ``Search timeseries on CreatedTime Ok`` () =
     // Arrange
     let timerange =
         TimeRange(
@@ -126,7 +121,7 @@ let ``Search timeseries on CreatedTime Ok`` () = task {
         )
 
     // Act
-    let! dtos = writeClient.TimeSeries.SearchAsync query
+    let dtos = writeClient.TimeSeries.Search query
 
     let len = Seq.length dtos
 
@@ -135,10 +130,9 @@ let ``Search timeseries on CreatedTime Ok`` () = task {
     // Assert
     test <@ len = 2 @>
     test <@ createdTime = 1567707299042L @>
-}
 
 [<Fact>]
-let ``Search timeseries on LastUpdatedTime Ok`` () = task {
+let ``Search timeseries on LastUpdatedTime Ok`` () =
     // Arrange
     let timerange =
         TimeRange(
@@ -153,7 +147,7 @@ let ``Search timeseries on LastUpdatedTime Ok`` () = task {
         )
 
     // Act
-    let! dtos = writeClient.TimeSeries.SearchAsync query
+    let dtos = writeClient.TimeSeries.Search query
     let len = Seq.length dtos
 
     let lastUpdatedTime = (Seq.head dtos).LastUpdatedTime
@@ -161,10 +155,10 @@ let ``Search timeseries on LastUpdatedTime Ok`` () = task {
     // Assert
     test <@ len = 2 @>
     test <@ lastUpdatedTime = 1567707299042L @>
-}
+
 
 [<Fact>]
-let ``Search timeseries on AssetIds is Ok`` () = task {
+let ``Search timeseries on AssetIds is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSearch(
@@ -173,7 +167,7 @@ let ``Search timeseries on AssetIds is Ok`` () = task {
         )
 
     // Act
-    let! dtos = readClient.TimeSeries.SearchAsync query
+    let dtos = readClient.TimeSeries.Search query
 
     let len = Seq.length dtos
 
@@ -182,10 +176,9 @@ let ``Search timeseries on AssetIds is Ok`` () = task {
     // Assert
     test <@ len = 1 @>
     test <@ Seq.forall ((=) (4293345866058133L)) assetIds @>
-}
 
 [<Fact>]
-let ``Search timeseries on ExternalIdPrefix is Ok`` () = task {
+let ``Search timeseries on ExternalIdPrefix is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSearch(
@@ -194,7 +187,7 @@ let ``Search timeseries on ExternalIdPrefix is Ok`` () = task {
         )
 
     // Act
-    let! dtos = readClient.TimeSeries.SearchAsync query
+    let dtos = readClient.TimeSeries.Search query
     let len = Seq.length dtos
 
     let externalIds = Seq.map (fun (d : TimeSeries) -> d.ExternalId) dtos
@@ -202,10 +195,9 @@ let ``Search timeseries on ExternalIdPrefix is Ok`` () = task {
     // Assert
     test <@ len > 1 @>
     test <@ Seq.forall (fun (e: string) -> e.StartsWith("pi:1636")) externalIds @>
-}
 
 [<Fact>]
-let ``Search timeseries on IsStep is Ok`` () = task {
+let ``Search timeseries on IsStep is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSearch(
@@ -214,7 +206,7 @@ let ``Search timeseries on IsStep is Ok`` () = task {
         )
 
     // Act
-    let! dtos = readClient.TimeSeries.SearchAsync query
+    let dtos = readClient.TimeSeries.Search query
 
     let len = Seq.length dtos
 
@@ -223,10 +215,9 @@ let ``Search timeseries on IsStep is Ok`` () = task {
     // Assert
     test <@ len > 0 @>
     test <@ Seq.forall id isSteps @>
-}
 
 [<Fact>]
-let ``Search timeseries on IsString is Ok`` () = task {
+let ``Search timeseries on IsString is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSearch(
@@ -235,7 +226,7 @@ let ``Search timeseries on IsString is Ok`` () = task {
         )
 
     // Act
-    let! dtos = readClient.TimeSeries.SearchAsync query
+    let dtos = readClient.TimeSeries.Search query
 
     let len = Seq.length dtos
     let isStrings = Seq.map (fun (d: TimeSeries) -> d.IsString) dtos
@@ -243,10 +234,9 @@ let ``Search timeseries on IsString is Ok`` () = task {
     // Assert
     test <@ len > 0 @>
     test <@ Seq.forall id isStrings @>
-}
 
 [<Fact>]
-let ``Search timeseries on Unit is Ok`` () = task {
+let ``Search timeseries on Unit is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSearch(
@@ -254,7 +244,7 @@ let ``Search timeseries on Unit is Ok`` () = task {
             Limit = Nullable 10
         )
     // Act
-    let! dtos = writeClient.TimeSeries.SearchAsync query
+    let dtos = writeClient.TimeSeries.Search query
 
     let len = Seq.length dtos
 
@@ -263,10 +253,9 @@ let ``Search timeseries on Unit is Ok`` () = task {
     // Assert
     test <@ len > 1 @>
     test <@ Seq.forall ((=) "et") units @>
-}
 
 [<Fact>]
-let ``Search timeseries on MetaData is Ok`` () = task {
+let ``Search timeseries on MetaData is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSearch(
@@ -274,7 +263,7 @@ let ``Search timeseries on MetaData is Ok`` () = task {
             Limit = Nullable 10
         )
     // Act
-    let! items = readClient.TimeSeries.SearchAsync query
+    let items = readClient.TimeSeries.Search query
 
     let len = Seq.length items
     let ms = Seq.map (fun (d: TimeSeries) -> d.Metadata) items
@@ -282,10 +271,9 @@ let ``Search timeseries on MetaData is Ok`` () = task {
     // Assert
     test <@ len > 0 @>
     test <@ Seq.forall (fun (m: Dictionary<string,string>) -> m.["pointid"] = "160909") ms @>
-}
 
 [<Fact>]
-let ``FuzzySearch timeseries on Name is Ok`` () = task {
+let ``FuzzySearch timeseries on Name is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSearch(
@@ -293,7 +281,7 @@ let ``FuzzySearch timeseries on Name is Ok`` () = task {
             Limit = Nullable 10
         )
     // Act
-    let! items = readClient.TimeSeries.SearchAsync query
+    let items = readClient.TimeSeries.Search query
 
     let len = Seq.length items
 
@@ -302,10 +290,9 @@ let ``FuzzySearch timeseries on Name is Ok`` () = task {
     // Assert
     test <@ len > 0 @>
     test <@ Seq.forall (fun (n: string) -> n.Contains("SILch0") || n.Contains("92529")) names @>
-}
 
 [<Fact>]
-let ``FuzzySearch timeseries on Description is Ok`` () = task {
+let ``FuzzySearch timeseries on Description is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSearch(
@@ -314,7 +301,7 @@ let ``FuzzySearch timeseries on Description is Ok`` () = task {
         )
 
     // Act
-    let! dtos = readClient.TimeSeries.SearchAsync query
+    let dtos = readClient.TimeSeries.Search query
 
     let len = Seq.length dtos
 
@@ -323,10 +310,9 @@ let ``FuzzySearch timeseries on Description is Ok`` () = task {
     // Assert
     test <@ len = 10 @>
     test <@ Seq.forall (fun (n: string) -> n.Contains("Tube")) descriptions @>
-}
 
 [<Fact>]
-let ``Update timeseries is Ok`` () = task {
+let ``Update timeseries is Ok`` () =
     // Arrange
 
     let newMetadata =
@@ -350,9 +336,9 @@ let ``Update timeseries is Ok`` () = task {
     let newDescription = "testdescription"
 
     // Act
-    let! createRes = writeClient.TimeSeries.CreateAsync [ dto ]
-    let! updateRes =
-        writeClient.TimeSeries.UpdateAsync [
+    let createRes = writeClient.TimeSeries.Create [ dto ]
+    let updateRes =
+        writeClient.TimeSeries.Update [
             TimeSeriesUpdateItem(
                 externalId = externalId,
                 Update = TimeSeriesUpdate(
@@ -364,8 +350,8 @@ let ``Update timeseries is Ok`` () = task {
                 )
             )
         ]
-    let! getRes = writeClient.TimeSeries.RetrieveAsync [ newExternalId ]
-    let! deleteRes = writeClient.TimeSeries.DeleteAsync [ newExternalId ]
+    let getRes = writeClient.TimeSeries.Retrieve [ newExternalId ]
+    let deleteRes = writeClient.TimeSeries.Delete [ newExternalId ]
 
     let resExternalId, resMetaData, resDescription =
         let head = Seq.tryHead getRes
@@ -385,10 +371,9 @@ let ``Update timeseries is Ok`` () = task {
     test <@ metaDataOk @>
 
     // Assert delete
-}
 
 [<Fact>]
-let ``Synthetic Query is Ok`` () = task {
+let ``Synthetic Query is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSyntheticQuery(
@@ -398,7 +383,7 @@ let ``Synthetic Query is Ok`` () = task {
         )
 
     // Act
-    let! res = readClient.TimeSeries.SyntheticQueryAsync(query)
+    let res = readClient.TimeSeries.SyntheticQuery(query)
 
     let ts = res |> Seq.head |> (fun x -> x.DataPoints)
 
@@ -406,10 +391,9 @@ let ``Synthetic Query is Ok`` () = task {
     test <@ ts |> Seq.length <= 10 @>
     test <@ ts |> Seq.length > 0 @>
     test <@ ts |> Seq.forall (fun x -> isNull x.Error) @>
-}
 
 [<Fact>]
-let ``Synthetic Query with Error is Ok`` () = task {
+let ``Synthetic Query with Error is Ok`` () =
     // Arrange
     let query =
         TimeSeriesSyntheticQuery(
@@ -419,11 +403,10 @@ let ``Synthetic Query with Error is Ok`` () = task {
         )
 
     // Act
-    let! res = readClient.TimeSeries.SyntheticQueryAsync(query)
+    let res = readClient.TimeSeries.SyntheticQuery(query)
 
     let ts = res |> Seq.head |> (fun x -> x.DataPoints)
 
     // Assert
     test <@ ts |> Seq.length > 0 @>
     test <@ ts |> Seq.forall (fun x -> x.Error |> (not << isNull)) @>
-}

--- a/CogniteSdk/test/fsharp/TimeSeries.fs
+++ b/CogniteSdk/test/fsharp/TimeSeries.fs
@@ -38,6 +38,28 @@ let ``Count timeseries is Ok`` () = task {
 }
 
 [<Fact>]
+let ``Get timeseries by id is Ok`` () = task {
+    // Arrange
+    let id = 6190956317771L
+
+    // Act
+    let! item = readClient.TimeSeries.GetAsync id
+
+    // Assert
+    test <@ item.Id = id @>
+}
+
+[<Fact>]
+let ``Get timeseries by missing id is Error`` () = task {
+    // Arrange
+    let id = 0L
+
+    // Act
+    Assert.ThrowsAsync<ArgumentException>(fun () -> readClient.TimeSeries.GetAsync id :> _)
+    |> ignore
+}
+
+[<Fact>]
 let ``Get timeseries by ids is Ok`` () = task {
     // Arrange
     let id = 6190956317771L
@@ -59,7 +81,7 @@ let ``Get timeseries by ids is Ok`` () = task {
 }
 
 [<Fact>]
-let ``Get timeseries by missing id is Error`` () = task {
+let ``Get timeseries by missing ids is Error`` () = task {
     // Arrange
     let id = Identity 0L
 

--- a/CogniteSdk/test/fsharp/TimeSeries.fs
+++ b/CogniteSdk/test/fsharp/TimeSeries.fs
@@ -320,19 +320,20 @@ let ``Update timeseries is Ok`` () =
             "key1", "value1"
             "key2", "value2"
         ] |> Dictionary
+    let externalIdString = Guid.NewGuid().ToString();
     let dto =
         TimeSeriesCreate(
             Metadata = (dict [
                 "oldkey1", "oldvalue1"
                 "oldkey2", "oldvalue2"
             ] |> Dictionary),
-            ExternalId = "testupdate",
+            ExternalId = externalIdString,
             Name = "testupdate",
             IsString = false,
             IsStep = false
         )
     let externalId = dto.ExternalId
-    let newExternalId = "testupdatenew"
+    let newExternalId = Guid.NewGuid().ToString();
     let newDescription = "testdescription"
 
     // Act

--- a/CogniteSdk/test/fsharp/TimeSeries.fs
+++ b/CogniteSdk/test/fsharp/TimeSeries.fs
@@ -69,6 +69,38 @@ let ``Get timeseries by missing id is Error`` () = task {
 }
 
 [<Fact>]
+let ``Get timeseries with metadata is Ok`` () = task {
+    // Arrange
+    let timeseriesId = 6190956317771L
+
+    // Act
+    let! res = readClient.TimeSeries.GetAsync timeseriesId
+
+    let md = res.Metadata
+
+    // Assert
+    test <@ not (isNull md) @>
+    test <@ md.["instrumenttag"] = "23-PDT-92501:X.Value" @>
+}
+
+[<Fact>]
+let ``Get timeseries without metadata is Ok`` () = task {
+    // Arrange
+    let timeseriesId = 6190956317771L
+
+    // Act
+    let! res = readClient.TimeSeries.GetAsync<TimeSeriesWithoutMetadata> timeseriesId
+
+    let resId = res.Id
+
+    // Assert
+    let md = res.Metadata
+
+    // Assert
+    test <@ isNull md @>
+}
+
+[<Fact>]
 let ``Create and delete timeseries is Ok`` () = task {
     // Arrange
     let externalIdString = Guid.NewGuid().ToString();

--- a/Oryx.Cognite/src/Assets.fs
+++ b/Oryx.Cognite/src/Assets.fs
@@ -20,7 +20,7 @@ module Assets =
     let Url = "/assets"
 
     /// Retrieves information about an asset given an asset id. Returns asset with the given id.
-    let get (assetId: int64) : HttpHandler<HttpResponseMessage, Asset, 'a> =
+    let get (assetId: int64) : HttpHandler<HttpResponseMessage, #Asset, 'TResult> =
         withLogMessage "Assets:get"
         >=> getById assetId Url
 
@@ -29,7 +29,7 @@ module Assets =
     /// </summary>
     /// <param name="query">The query to use.</param>
     /// <returns>List of assets matching given filters and optional cursor</returns>
-    let list (query: AssetQuery) : HttpHandler<HttpResponseMessage, ItemsWithCursor<Asset>, 'a> =
+    let list (query: AssetQuery) : HttpHandler<HttpResponseMessage, ItemsWithCursor<#Asset>, 'TResult> =
         withLogMessage "Assets:list"
         >=> list query Url
 
@@ -38,7 +38,7 @@ module Assets =
     /// </summary>
     /// <param name="query">The query to use.</param>
     /// <returns>List of assets matching given filters</returns>
-    let aggregate (query: AssetQuery) : HttpHandler<HttpResponseMessage, int, 'a> =
+    let aggregate (query: AssetQuery) : HttpHandler<HttpResponseMessage, int, 'TResult> =
         withLogMessage "Assets:aggregate"
         >=> aggregate query Url
 
@@ -47,7 +47,7 @@ module Assets =
     /// </summary>
     /// <param name="assets">The assets to create.</param>
     /// <returns>List of created assets.</returns>
-    let create (items: AssetCreate seq) : HttpHandler<HttpResponseMessage, Asset seq, 'a> =
+    let create (items: AssetCreate seq) : HttpHandler<HttpResponseMessage, Asset seq, 'TResult> =
         withLogMessage "Assets:create"
         >=> create items Url
 
@@ -56,7 +56,7 @@ module Assets =
     /// </summary>
     /// <param name="assets">The list of assets to delete.</param>
     /// <returns>Empty result.</returns>
-    let delete (assets: AssetDelete) : HttpHandler<HttpResponseMessage, EmptyResponse, 'a> =
+    let delete (assets: AssetDelete) : HttpHandler<HttpResponseMessage, EmptyResponse, 'TResult> =
         withLogMessage "Assets:delete"
         >=> delete assets Url
 
@@ -66,7 +66,7 @@ module Assets =
     /// </summary>
     /// <param name="assetId">The ids of the assets to get.</param>
     /// <returns>Assets with given ids.</returns>
-    let retrieve (ids: Identity seq) (ignoreUnknownIds: Nullable<bool>) : HttpHandler<HttpResponseMessage, Asset seq, 'a> =
+    let retrieve (ids: Identity seq) (ignoreUnknownIds: Nullable<bool>) : HttpHandler<HttpResponseMessage, #Asset seq, 'TResult> =
         withLogMessage "Assets:retrieve"
         >=> retrieveIgnoreUnkownIds ids (Option.ofNullable ignoreUnknownIds) Url
 
@@ -75,12 +75,12 @@ module Assets =
     /// </summary>
     /// <param name="query">Asset search query.</param>
     /// <returns>List of assets matching given criteria.</returns>
-    let search (query: AssetSearch) : HttpHandler<HttpResponseMessage, Asset seq, 'a> =
+    let search (query: AssetSearch) : HttpHandler<HttpResponseMessage, #Asset seq, 'TResult> =
         withLogMessage "Assets:search"
         >=> search query Url
 
     /// Update one or more assets. Supports partial updates, meaning that fields omitted from the requests are not changed. Returns list of updated assets.
-    let update (query: IEnumerable<UpdateItem<AssetUpdate>>) : HttpHandler<HttpResponseMessage, Asset seq, 'a>  =
+    let update (query: IEnumerable<UpdateItem<AssetUpdate>>) : HttpHandler<HttpResponseMessage, #Asset seq, 'TResult>  =
         withLogMessage "Assets:update"
         >=> update query Url
 

--- a/Oryx.Cognite/src/Events.fs
+++ b/Oryx.Cognite/src/Events.fs
@@ -23,7 +23,7 @@ module Events =
     /// </summary>
     /// <param name="eventId">The id of the event to get.</param>
     /// <returns>Event with the given id.</returns>
-    let get (eventId: int64) : HttpHandler<HttpResponseMessage, Event, 'a> =
+    let get (eventId: int64) : HttpHandler<HttpResponseMessage, #Event, 'TResult> =
         withLogMessage "Events:get"
         >=> getById eventId Url
 
@@ -32,7 +32,7 @@ module Events =
     /// </summary>
     /// <param name="query">The query to use.</param>
     /// <returns>List of events matching given filters and optional cursor</returns>
-    let list (query: EventQuery) : HttpHandler<HttpResponseMessage, ItemsWithCursor<Event>, 'a> =
+    let list (query: EventQuery) : HttpHandler<HttpResponseMessage, ItemsWithCursor<#Event>, 'TResult> =
         withLogMessage "Events:list"
         >=> list query Url
 
@@ -41,7 +41,7 @@ module Events =
     /// </summary>
     /// <param name="query">The query to use.</param>
     /// <returns>Number of events matching given filters and optional cursor</returns>
-    let aggregate (query: EventQuery) : HttpHandler<HttpResponseMessage, int32, 'a> =
+    let aggregate (query: EventQuery) : HttpHandler<HttpResponseMessage, int32, 'TResult> =
         withLogMessage "Events:aggregate"
         >=> aggregate query Url
 
@@ -50,7 +50,7 @@ module Events =
     /// </summary>
     /// <param name="items">The events to create.</param>
     /// <returns>List of created events.</returns>
-    let create (items: EventCreate seq) : HttpHandler<HttpResponseMessage, Event seq, 'a> =
+    let create (items: EventCreate seq) : HttpHandler<HttpResponseMessage, #Event seq, 'TResult> =
         withLogMessage "Events:create"
         >=> create items Url
 
@@ -59,7 +59,7 @@ module Events =
     /// </summary>
     /// <param name="items">The list of events to delete.</param>
     /// <returns>Empty result.</returns>
-    let delete (items: EventDelete) : HttpHandler<HttpResponseMessage, EmptyResponse, 'a> =
+    let delete (items: EventDelete) : HttpHandler<HttpResponseMessage, EmptyResponse, 'TResult> =
         withLogMessage "Events:delete"
         >=> delete items Url
 
@@ -70,7 +70,7 @@ module Events =
     /// <param name="ids">The ids of the events to get.</param>
     /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
     /// <returns>Events with given ids.</returns>
-    let retrieve (ids: Identity seq) (ignoreUnknownIds: Nullable<bool>) : HttpHandler<HttpResponseMessage, Event seq, 'a> =
+    let retrieve (ids: Identity seq) (ignoreUnknownIds: Nullable<bool>) : HttpHandler<HttpResponseMessage, #Event seq, 'TResult> =
         withLogMessage "Events:retrieve"
         >=> retrieveIgnoreUnkownIds ids (Option.ofNullable ignoreUnknownIds) Url
 
@@ -79,7 +79,7 @@ module Events =
     /// </summary>
     /// <param name="query">Event search query.</param>
     /// <returns>List of events matching given criteria.</returns>
-    let search (query: EventSearch) : HttpHandler<HttpResponseMessage, Event seq, 'a> =
+    let search (query: EventSearch) : HttpHandler<HttpResponseMessage, #Event seq, 'TResult> =
         withLogMessage "Events:search"
         >=> search query Url
 
@@ -88,7 +88,7 @@ module Events =
     /// </summary>
     /// <param name="query">The list of events to update.</param>
     /// <returns>List of updated events.</returns>
-    let update (query: UpdateItem<EventUpdate> seq) : HttpHandler<HttpResponseMessage, Event seq, 'a>  =
+    let update (query: UpdateItem<EventUpdate> seq) : HttpHandler<HttpResponseMessage, #Event seq, 'TResult>  =
         withLogMessage "Events:update"
         >=> update query Url
 

--- a/Oryx.Cognite/src/TimeSeries.fs
+++ b/Oryx.Cognite/src/TimeSeries.fs
@@ -18,6 +18,12 @@ module TimeSeries =
     [<Literal>]
     let Url = "/timeseries"
 
+    /// Retrieves information about an time series given an time series id. Returns asset with the given id.
+    let get (tsId: int64) : HttpHandler<HttpResponseMessage, #TimeSeries, 'TResult> =
+        withLogMessage "Assets:get"
+        >=> retrieve [ Identity tsId ] Url
+        >=> map Seq.head
+
     /// Retrieves list of time series matching filter, and a cursor if given limit is exceeded. Returns list of time
     /// series matching given filters and optional cursor.
     let list (query: TimeSeriesQuery) : HttpHandler<HttpResponseMessage, ItemsWithCursor<#TimeSeries>, 'TResult> =

--- a/Oryx.Cognite/src/TimeSeries.fs
+++ b/Oryx.Cognite/src/TimeSeries.fs
@@ -20,7 +20,7 @@ module TimeSeries =
 
     /// Retrieves information about an time series given an time series id. Returns asset with the given id.
     let get (tsId: int64) : HttpHandler<HttpResponseMessage, #TimeSeries, 'TResult> =
-        withLogMessage "Assets:get"
+        withLogMessage "TimeSeries:get"
         >=> retrieve [ Identity tsId ] Url
         >=> map Seq.head
 

--- a/Oryx.Cognite/src/TimeSeries.fs
+++ b/Oryx.Cognite/src/TimeSeries.fs
@@ -20,51 +20,51 @@ module TimeSeries =
 
     /// Retrieves list of time series matching filter, and a cursor if given limit is exceeded. Returns list of time
     /// series matching given filters and optional cursor.
-    let list (query: TimeSeriesQuery) : HttpHandler<HttpResponseMessage, ItemsWithCursor<TimeSeries>, 'a> =
+    let list (query: TimeSeriesQuery) : HttpHandler<HttpResponseMessage, ItemsWithCursor<#TimeSeries>, 'TResult> =
         withLogMessage "TimeSeries:get"
         >=> list query Url
 
     /// Retrieves number of time series matching filter. Returns number of time
     /// series matching given filters.
-    let aggregate (query: TimeSeriesQuery) : HttpHandler<HttpResponseMessage, int32, 'a> =
+    let aggregate (query: TimeSeriesQuery) : HttpHandler<HttpResponseMessage, int32, 'TResult> =
         withLogMessage "TimeSeries:aggregate"
         >=> aggregate query Url
 
     /// Create one or more new time series. Returns list of created time series.
-    let create (items: IEnumerable<TimeSeriesCreate>) : HttpHandler<HttpResponseMessage, IEnumerable<TimeSeries>, 'a> =
+    let create (items: IEnumerable<TimeSeriesCreate>) : HttpHandler<HttpResponseMessage, IEnumerable<#TimeSeries>, 'TResult> =
         withLogMessage "TimeSeries:create"
         >=> create items Url
 
     /// Delete one or more time series.
-    let delete (items: TimeSeriesDelete) : HttpHandler<HttpResponseMessage, EmptyResponse, 'a> =
+    let delete (items: TimeSeriesDelete) : HttpHandler<HttpResponseMessage, EmptyResponse, 'TResult> =
         withLogMessage "TimeSeries:delete"
         >=> delete items Url
 
     /// Retrieves information about multiple time series in the same project. A maximum of 1000 time series IDs may be
     /// listed per request and all of them must be unique. Returns the time series with the given ids.
-    let retrieve (ids: Identity seq) (ignoreUnknownIds: Nullable<bool>) : HttpHandler<HttpResponseMessage, TimeSeries seq, 'a> =
+    let retrieve (ids: Identity seq) (ignoreUnknownIds: Nullable<bool>) : HttpHandler<HttpResponseMessage, #TimeSeries seq, 'TResult> =
         withLogMessage "TimeSeries:retrieve"
         >=> retrieveIgnoreUnkownIds ids (Option.ofNullable ignoreUnknownIds) Url
 
     /// Retrieves a list of time series matching the given criteria. This operation does not support pagination. Returns
     /// list of time series matching given criteria.
-    let search (query: TimeSeriesSearch) : HttpHandler<HttpResponseMessage, TimeSeries seq, 'a> =
+    let search (query: TimeSeriesSearch) : HttpHandler<HttpResponseMessage, #TimeSeries seq, 'TResult> =
         withLogMessage "TimeSeries:search"
         >=> search query Url
 
     /// Updates multiple time series within the same project. This operation supports partial updates, meaning that
     /// fields omitted from the requests are not changed Returns list of updated time series.
-    let update (query: IEnumerable<UpdateItem<TimeSeriesUpdate>>) : HttpHandler<HttpResponseMessage, TimeSeries seq, 'a>  =
+    let update (query: IEnumerable<UpdateItem<TimeSeriesUpdate>>) : HttpHandler<HttpResponseMessage, #TimeSeries seq, 'TResult>  =
         withLogMessage "TimeSeries:update"
         >=> update query Url
 
     /// Executes an on-the-fly synthetic query
     /// For example you can use the expression "24 * ts{externalId='production/hour'}" to convert from hourly to daily production rates.
     /// More about synthetic queries https://docs.cognite.com/dev/concepts/resource_types/timeseries.html#synthetic-time-series
-    let syntheticQuery (query: TimeSeriesSyntheticQuery) : HttpHandler<HttpResponseMessage, IEnumerable<DataPointsSyntheticItem>, 'a> =
+    let syntheticQuery (query: TimeSeriesSyntheticQuery) : HttpHandler<HttpResponseMessage, IEnumerable<DataPointsSyntheticItem>, 'TResult> =
         withLogMessage "TimeSeries:syntheticQuery"
         >=> req {
             let url = Url +/ "synthetic/query"
-            let! ret = postV10<TimeSeriesSyntheticQuery, ItemsWithoutCursor<DataPointsSyntheticItem>, 'a> query url
+            let! ret = postV10<TimeSeriesSyntheticQuery, ItemsWithoutCursor<DataPointsSyntheticItem>, 'TResult> query url
             return ret.Items
-        } 
+        }

--- a/Oryx.Cognite/src/Types.fs
+++ b/Oryx.Cognite/src/Types.fs
@@ -8,10 +8,10 @@ open Oryx
 open CogniteSdk
 
 // Shadow types for Oryx that pins the error type to ResponseError
-type HttpFuncResult<'r> = Task<Result<Context<'r>, HandlerError<ResponseException>>>
-type HttpFunc<'a, 'r> = Context<'a> -> HttpFuncResult<'r, ResponseException>
-type NextFunc<'a, 'r> = HttpFunc<'a, 'r, ResponseException>
-type public HttpHandler<'a, 'b, 'r> = HttpFunc<'b, 'r, ResponseException> -> Context<'a> -> HttpFuncResult<'r, ResponseException>
-type HttpHandler<'a, 'r> = HttpHandler<'a, 'a, 'r, ResponseException>
-type HttpHandler<'r> = HttpHandler<HttpResponseMessage, 'r, ResponseException>
+type HttpFuncResult<'TResult> = Task<Result<Context<'TResult>, HandlerError<ResponseException>>>
+type HttpFunc<'T, 'TResult> = Context<'T> -> HttpFuncResult<'TResult, ResponseException>
+type NextFunc<'T, 'TResult> = HttpFunc<'T, 'TResult, ResponseException>
+type public HttpHandler<'T, 'TNext, 'TResult> = HttpFunc<'TNext, 'TResult, ResponseException> -> Context<'T> -> HttpFuncResult<'TResult, ResponseException>
+type HttpHandler<'T, 'TResult> = HttpHandler<'T, 'T, 'TResult, ResponseException>
+type HttpHandler<'T> = HttpHandler<HttpResponseMessage, 'T, ResponseException>
 type HttpHandler = HttpHandler<HttpResponseMessage, ResponseException>


### PR DESCRIPTION
- Enable resource type overrides to e.g exclude meta-data in responses for Assets, Events and TimeSeries.
- Make `MultiValue` JSON encoder output number instead of string for double and long.
- Make `HttpHandler` types explicit with capital letter types (previously they look inferred).
- Add `GetAsync` method for time series API.