### PR TITLE
Data sets

### DIFF
--- a/CogniteSdk.Types/DataSets/DataSet.cs
+++ b/CogniteSdk.Types/DataSets/DataSet.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2020 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+using CogniteSdk.Types.Common;
+using System.Collections.Generic;
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// The DataSet read class
+    /// </summary>
+    public class DataSet
+    {
+        /// <summary>
+        /// The external ID provided by the client. Must be unique within the project.
+        /// </summary>
+        public string ExternalId { get; set; }
+        /// <summary>
+        /// The name of the data set.
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// The description of the data set.
+        /// </summary>
+        public string Description { get; set; }
+        /// <summary>
+        /// Custom, application specific metadata. String key -> String value.
+        /// </summary>
+        public Dictionary<string, string> Metadata { get; set; }
+        /// <summary>
+        /// To write data to a write-protected data set,
+        /// you need to be a member of a group that has the "datasets:owner" action for the data set.
+        /// </summary>
+        public bool WriteProtected { get; set; }
+        /// <summary>
+        /// The Id of this data set.
+        /// </summary>
+        public long Id { get; set; }
+        /// <summary>
+        /// Time when this data set was created in CDF in milliseconds since Jan 1, 1970.
+        /// </summary>
+        public long CreatedTime { get; set; }
+        /// <summary>
+        /// The last time this data set was updated in CDF, in milliseconds since Jan 1, 1970.
+        /// </summary>
+        public long LastUpdatedTime { get; set; }
+        /// <summary>Determines whether the specified object is equal to the current object, using internalId</summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            return obj is DataSet dto && dto.Id == Id;
+        }
+        /// <summary>
+        /// Creates a hash code based on the Id attribute.
+        /// </summary>
+        /// <returns>A hash code for the current object</returns>
+        public override int GetHashCode()
+        {
+            return 2108858624 + Id.GetHashCode();
+        }
+        /// <inheritdoc />
+        public override string ToString() => Stringable.ToString(this);
+    }
+}

--- a/CogniteSdk.Types/DataSets/DataSet.cs
+++ b/CogniteSdk.Types/DataSets/DataSet.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 using CogniteSdk.Types.Common;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace CogniteSdk
 {
@@ -60,5 +61,16 @@ namespace CogniteSdk
         }
         /// <inheritdoc />
         public override string ToString() => Stringable.ToString(this);
+    }
+    /// <summary>
+    /// Data set read class (without metadata).
+    /// </summary>
+    public class DataSetWithoutMetadata : DataSet
+    {
+        /// <summary>
+        /// Custom, application specific metadata. String key -> String value
+        /// </summary>
+        [JsonIgnore]
+        public new Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/CogniteSdk.Types/DataSets/DataSetCreate.cs
+++ b/CogniteSdk.Types/DataSets/DataSetCreate.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+using System.Collections.Generic;
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// Class for creating a new data set
+    /// </summary>
+    public class DataSetCreate
+    {
+        /// <summary>
+        /// The external ID provided by the client. Must be unique within the project.
+        /// </summary>
+        public string ExternalId { get; set; }
+        /// <summary>
+        /// The name of the data set.
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// The description of the data set.
+        /// </summary>
+        public string Description { get; set; }
+        /// <summary>
+        /// Custom, application specific metadata. String key -> String value.
+        /// </summary>
+        public Dictionary<string, string> Metadata { get; set; }
+        /// <summary>
+        /// To write data to a write-protected data set,
+        /// you need to be a member of a group that has the "datasets:owner" action for the data set.
+        /// </summary>
+        public bool WriteProtected { get; set; }
+    }
+}

--- a/CogniteSdk.Types/DataSets/DataSetFilter.cs
+++ b/CogniteSdk.Types/DataSets/DataSetFilter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// The data set filter class.
+    /// </summary>
+    public class DataSetFilter
+    {
+        /// <summary>
+        /// Custom, application specific metadata. String key -> String value.
+        /// </summary>
+        public Dictionary<string, string> Metadata { get; set; }
+        /// <summary>
+        /// Range between two timestamps.
+        /// </summary>
+        public TimeRange CreatedTime { get; set; }
+        /// <summary>
+        /// Range between two timestamps.
+        /// </summary>
+        public TimeRange LastUpdatedTime { get; set; }
+        /// <summary>
+        /// Filter by this (case-sensitive) prefix for the external ID.
+        /// </summary>
+        public string ExternalIdPrefix { get; set; }
+        /// <summary>
+        /// Whether the data set is write protected.
+        /// </summary>
+        public bool WriteProtected { get; set; }
+    }
+}

--- a/CogniteSdk.Types/DataSets/DataSetQuery.cs
+++ b/CogniteSdk.Types/DataSets/DataSetQuery.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2020 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+using CogniteSdk.Types.Common;
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// Query containing filter and cursor for data sets.
+    /// </summary>
+    public class DataSetQuery : CursorQueryBase
+    {
+        /// <summary>
+        /// Filter on data sets with strict matching.
+        /// </summary>
+        public DataSetFilter Filter { get; set; }
+        /// <inheritdoc />
+        public override string ToString() => Stringable.ToString(this);
+    }
+}

--- a/CogniteSdk.Types/DataSets/DataSetUpdate.cs
+++ b/CogniteSdk.Types/DataSets/DataSetUpdate.cs
@@ -29,6 +29,7 @@ namespace CogniteSdk
         /// </summary>
         public Update<bool> WriteProtected { get; set; }
     }
+
     /// <summary>
     /// The data set update item type. Contains the update item for an <see cref="DataSetUpdate">DataSetUpdate</see>.
     /// </summary>

--- a/CogniteSdk.Types/DataSets/DataSetUpdate.cs
+++ b/CogniteSdk.Types/DataSets/DataSetUpdate.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// The data set update class.
+    /// </summary>
+    public class DataSetUpdate
+    {
+        /// <summary>
+        /// Set a new value for externalId, or remove the value.
+        /// </summary>
+        public UpdateNullable<string> ExternalId { get; set; }
+        /// <summary>
+        /// Set a new value for name, or remove the value.
+        /// </summary>
+        public UpdateNullable<string> Name { get; set; }
+        /// <summary>
+        /// Set a new value for description, or remove the value
+        /// </summary>
+        public UpdateNullable<string> Description { get; set; }
+        /// <summary>
+        /// Custom, application specific metadata. String key -> String value.
+        /// </summary>
+        public UpdateDictionary<string> Metadata { get; set; }
+        /// <summary>
+        /// Set a new value for the writeProtected field.
+        /// </summary>
+        public Update<bool> WriteProtected { get; set; }
+    }
+    /// <summary>
+    /// The data set update item type. Contains the update item for an <see cref="DataSetUpdate">DataSetUpdate</see>.
+    /// </summary>
+    public class DataSetUpdateItem : UpdateItem<DataSet>
+    {
+        /// <summary>
+        /// Initialize the data set update item with an external Id.
+        /// </summary>
+        /// <param name="externalId">External Id to set.</param>
+        public DataSetUpdateItem(string externalId) : base(externalId)
+        {
+        }
+
+        /// <summary>
+        /// Initialize the data set update item with an internal Id.
+        /// </summary>
+        /// <param name="id">Internal Id to set.</param>
+        public DataSetUpdateItem(long id) : base(id)
+        {
+        }
+    }
+}

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -69,6 +69,7 @@ namespace CogniteSdk
         /// Client Sequences extension methods
         /// </summary>
         public SequencesResource Sequences  { get; }
+
         /// <summary>
         /// Client DataSets extension methods
         /// </summary>

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -69,6 +69,10 @@ namespace CogniteSdk
         /// Client Sequences extension methods
         /// </summary>
         public SequencesResource Sequences  { get; }
+        /// <summary>
+        /// Client DataSets extension methods
+        /// </summary>
+        public DataSetsResource DataSets { get; }
 
         /// <summary>
         /// Client 3D Models extension methods
@@ -110,6 +114,7 @@ namespace CogniteSdk
             Sequences = new SequencesResource(authHandler, ctx);
             Raw = new RawResource(authHandler, ctx);
             Relationships = new RelationshipResource(authHandler, ctx);
+            DataSets = new DataSetsResource(authHandler, ctx);
             ThreeDModels = new ThreeDModelsResource(authHandler, ctx);
             ThreeDRevisions = new ThreeDRevisionsResource(authHandler, ctx);
             ThreeDAssetMappings = new ThreeDAssetMappingsResource(authHandler, ctx);

--- a/CogniteSdk/src/Resources/Assets.cs
+++ b/CogniteSdk/src/Resources/Assets.cs
@@ -60,7 +60,7 @@ namespace CogniteSdk.Resources
         /// </summary>
         /// <param name="query">The query filter to use.</param>
         /// <param name="token">Optional cancellation token to use.</param>
-        /// <returns>Number of assets matching given filters and optional cursor</returns>
+        /// <returns>Number of assets matching given filters</returns>
         public async Task<int> AggregateAsync(AssetQuery query, CancellationToken token = default)
         {
             if (query is null)

--- a/CogniteSdk/src/Resources/DataSets.cs
+++ b/CogniteSdk/src/Resources/DataSets.cs
@@ -79,5 +79,79 @@ namespace CogniteSdk.Resources
             var req = DataSets.aggregate(query);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
+
+        #region Retrieve overloads
+        /// <summary>
+        /// Asynchronously retrieves information about multiple data set like objects in the same project. A maximum of
+        /// 1000 data set IDs may be listed per request and all of them must be unique.
+        /// </summary>
+        /// <param name="ids">The list of data set identities to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <typeparam name="T">Type of data set to return, e.g DataSet or DataSetWithoutMetadata.</typeparam>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested data sets.</returns>
+        public async Task<IEnumerable<T>> RetrieveAsync<T>(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default) where T : DataSet
+        {
+            if (ids is null)
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
+            var req = DataSets.retrieve<T>(ids, ignoreUnknownIds);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves information about multiple data sets in the same project. A maximum of 1000 data set IDs
+        /// may be listed per request and all of them must be unique.
+        /// </summary>
+        /// <param name="ids">The list of data set identities to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested data sets.</returns>
+        public async Task<IEnumerable<DataSet>> RetrieveAsync(IEnumerable<Identity> ids, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            return await RetrieveAsync<DataSet>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves information about multiple data sets in the same project. A maximum of 1000 data set IDs
+        /// may be listed per request and all of them must be unique.
+        /// </summary>
+        /// <param name="internalIds">The list of data set internal identities to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested data sets.</returns>
+        public async Task<IEnumerable<DataSet>> RetrieveAsync(IEnumerable<long> internalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            if (internalIds is null)
+            {
+                throw new ArgumentNullException(nameof(internalIds));
+            }
+
+            var ids = internalIds.Select(Identity.Create);
+            return await RetrieveAsync<DataSet>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves information about multiple data sets in the same project. A maximum of 1000 data set IDs
+        /// may be listed per request and all of them must be unique.
+        /// </summary>
+        /// <param name="externalIds">The list of data set external identities to retrieve.</param>
+        /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found. Default: false</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A sequence of the requested data sets.</returns>
+        public async Task<IEnumerable<DataSet>> RetrieveAsync(IEnumerable<string> externalIds, bool? ignoreUnknownIds = null, CancellationToken token = default)
+        {
+            if (externalIds is null)
+            {
+                throw new ArgumentNullException(nameof(externalIds));
+            }
+
+            var ids = externalIds.Select(Identity.Create);
+            return await RetrieveAsync<DataSet>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
+        }
+
+        #endregion
     }
 }

--- a/CogniteSdk/src/Resources/DataSets.cs
+++ b/CogniteSdk/src/Resources/DataSets.cs
@@ -39,5 +39,31 @@ namespace CogniteSdk.Resources
             var req = DataSets.create(dataSets);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Asynchronously retrieve a list of data set like objects matching the given filter.
+        /// </summary>
+        /// <typeparam name="T">Type of data set to return, e.g. DataSet or DataSetWithoutMetadata.</typeparam>
+        /// <param name="query">The query filter to use.</param>
+        /// <param name="token">Optional cancellation token to use.</param>
+        /// <returns>List of data sets matching given filters and optional cursor</returns>
+        public async Task<IItemsWithCursor<T>> ListAsync<T>(DataSetQuery query, CancellationToken token = default) where T : DataSet
+        {
+            if (query is null) throw new ArgumentNullException(nameof(query));
+
+            var req = DataSets.list<T>(query);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieve a list of data sets matching query.
+        /// </summary>
+        /// <param name="query">The query filter to use.</param>
+        /// <param name="token">Optional cancellation token to use.</param>
+        /// <returns>List of data sets matching given filters and optional cursor</returns>
+        public async Task<ItemsWithCursor<DataSet>> ListAsync(DataSetQuery query, CancellationToken token = default)
+        {
+            return (ItemsWithCursor<DataSet>)await ListAsync<DataSet>(query, token).ConfigureAwait(false);
+        }
     }
 }

--- a/CogniteSdk/src/Resources/DataSets.cs
+++ b/CogniteSdk/src/Resources/DataSets.cs
@@ -65,5 +65,19 @@ namespace CogniteSdk.Resources
         {
             return (ItemsWithCursor<DataSet>)await ListAsync<DataSet>(query, token).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Asynchronously retrieve number of data sets matching query.
+        /// </summary>
+        /// <param name="query">The query filter to use</param>
+        /// <param name="token">Optional cancellation token</param>
+        /// <returns>Number of data sets matching given filters</returns>
+        public async Task<int> AggregateAsync(DataSetQuery query, CancellationToken token = default)
+        {
+            if (query is null) throw new ArgumentNullException(nameof(query));
+
+            var req = DataSets.aggregate(query);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
     }
 }

--- a/CogniteSdk/src/Resources/DataSets.cs
+++ b/CogniteSdk/src/Resources/DataSets.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Oryx;
+using Oryx.Cognite;
+
+namespace CogniteSdk.Resources
+{
+    /// <summary>
+    /// Contains all data set methods.
+    /// </summary>
+    public class DataSetsResource : Resource
+    {
+        /// <summary>
+        /// The class constructor. Will only be instantiated by the client.
+        /// </summary>
+        /// <param name="authHandler">Authentication handler.</param>
+        /// <param name="ctx">Context to use for the request.</param>
+        internal DataSetsResource(Func<CancellationToken, Task<string>> authHandler, Context ctx) : base(authHandler, ctx)
+        {
+        }
+
+        /// <summary>
+        /// Asynchronously create data sets.
+        /// </summary>
+        /// <param name="dataSets">Data sets to create.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>Sequence of created dataSets.</returns>
+        public async Task<IEnumerable<DataSet>> CreateAsync(IEnumerable<DataSetCreate> dataSets, CancellationToken token = default)
+        {
+            if (dataSets is null) throw new ArgumentNullException(nameof(dataSets));
+
+            var req = DataSets.create(dataSets);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/CogniteSdk/src/Resources/DataSets.cs
+++ b/CogniteSdk/src/Resources/DataSets.cs
@@ -151,7 +151,25 @@ namespace CogniteSdk.Resources
             var ids = externalIds.Select(Identity.Create);
             return await RetrieveAsync<DataSet>(ids, ignoreUnknownIds, token).ConfigureAwait(false);
         }
-
         #endregion
+
+        /// <summary>
+        /// Asynchronously update one or more data sets. Supports partial updates, meaning that fields omitted from the
+        /// requests are not changed
+        /// </summary>
+        /// <param name="query">The list of data sets to update.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>Sequence of updated data sets.</returns>
+        public async Task<IEnumerable<DataSet>> UpdateAsync(IEnumerable<DataSetUpdateItem> query, CancellationToken token = default)
+        {
+            if (query is null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            var req = DataSets.update<DataSet>(query);
+            var ret = await RunAsync(req, token).ConfigureAwait(false);
+            return ret;
+        }
     }
 }

--- a/CogniteSdk/test/fsharp/CogniteSdk.Test.fsproj
+++ b/CogniteSdk/test/fsharp/CogniteSdk.Test.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Files.fs" />
     <Compile Include="Functions.fs" />
     <Compile Include="Relationships.fs" />
+    <Compile Include="DataSets.fs" />
     <Compile Include="Login.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/CogniteSdk/test/fsharp/DataSets.fs
+++ b/CogniteSdk/test/fsharp/DataSets.fs
@@ -1,0 +1,177 @@
+﻿module Tests.Integration.DataSets
+
+open System
+open System.Collections.Generic
+
+open FSharp.Control.Tasks.V2.ContextInsensitive
+open Swensen.Unquote
+open Oryx
+open Xunit
+
+open CogniteSdk
+open Common
+
+[<Fact>]
+let ``List data sets with limit is OK`` () = task {
+    // Arrange
+    let query = DataSetQuery(Limit= Nullable 2)
+
+    // Act
+    let! res = readClient.DataSets.ListAsync(query)
+    let len = Seq.length res.Items
+
+    // Assert
+    test <@ len = 2 @>
+}
+
+[<Fact>]
+let ``Filter data sets by metadata is OK`` () = task {
+    // Arrange
+    let meta = Dictionary (dict [("consoleSource", "{\"names\":[\"PI\"]}")])
+    let filter = DataSetFilter(Metadata = meta)
+    let query = DataSetQuery(Filter = filter)
+
+    // Act
+    let! res = readClient.DataSets.ListAsync(query)
+    let len = Seq.length res.Items
+    let item = Seq.item 0 res.Items
+
+    // Assert
+    test <@ len = 1 @>
+    test <@ (item.Metadata.Item "consoleSource") = "{\"names\":[\"PI\"]}" @>
+    test <@ item.Name = "Valhall system 23 time series" @>
+}
+
+let ``Filter data sets by created time is OK`` () = task {
+    // Arrange
+    let range = TimeRange(Min = 1586596603465L, Max = 1586596605465L)
+    let filter = DataSetFilter(CreatedTime = range)
+    let query = DataSetQuery(Filter = filter)
+
+    // Act
+    let! res = readClient.DataSets.ListAsync(query)
+    let len = Seq.length res.Items
+    let item = Seq.item 0 res.Items
+
+    // Assert
+    test <@ len = 1 @>
+    test <@ item.CreatedTime = 1586596604465L @>
+    test <@ item.Name = "Valhall system 23 time series" @>
+}
+
+let ``Filter data sets by last updated time is OK`` () = task {
+    // Arrange
+    let range = TimeRange(Min = 1586953700640L, Max = 1586953700840L)
+    let filter = DataSetFilter(CreatedTime = range)
+    let query = DataSetQuery(Filter = filter)
+
+    // Act
+    let! res = readClient.DataSets.ListAsync(query)
+    let len = Seq.length res.Items
+    let item = Seq.item 0 res.Items
+
+    // Assert
+    test <@ len = 1 @>
+    test <@ item.LastUpdatedTime = 1586953700740L @>
+    test <@ item.Name = "Valhall system 23 time series" @>
+}
+
+let ``Filter data sets by externalIdPrefix is OK`` () = task {
+    // Arrange
+    let filter = DataSetFilter(ExternalIdPrefix = "OID/VAL/")
+    let query = DataSetQuery(Filter = filter)
+
+    // Act
+    let! res = readClient.DataSets.ListAsync(query)
+    let len = Seq.length res.Items
+
+    // Assert
+    test <@ len = 2 @>
+}
+
+let ``Filter data sets by writeProtected is OK`` () = task {
+    // Arrange
+    let filter = DataSetFilter(WriteProtected = true)
+    let query = DataSetQuery(Filter = filter)
+
+    let! res = readClient.DataSets.ListAsync(query)
+    let len = Seq.length res.Items
+
+    // Assert
+    test <@ len = 0 @>
+}
+
+let ``List data sets without metadata is OK`` () = task {
+    // Arrange
+    let query = DataSetQuery()
+
+    // Act
+    let! res = readClient.DataSets.ListAsync<DataSetWithoutMetadata>(query)
+    let len = Seq.length res.Items
+    let item = Seq.item 0 res.Items
+
+    // Assert
+    test <@ len = 3 @>
+    test <@ isNull item.Metadata @>
+}
+
+let ``Aggregate data sets with filter is OK`` = task {
+    // Arrange
+    let filter = DataSetFilter(ExternalIdPrefix = "OID/VAL/")
+    let query = DataSetQuery(Filter = filter)
+
+    // Act
+    let! res = readClient.DataSets.AggregateAsync(query)
+    
+    // Assert
+    test <@ res = 2 @>
+}
+
+let ``Retrieve data sets mixed is OK`` = task {
+    // Arrange
+    let ids = [ Identity.Create(6973832320392714L); Identity.Create("OID/VAL/Assets") ]
+
+    // Act
+    let! res = readClient.DataSets.RetrieveAsync ids
+    let len = Seq.length res
+
+    // Assert
+    test <@ len = 2 @>
+}
+
+let ``Retrieve data sets without metadata is OK`` = task {
+    // Arrange
+    let ids = [ Identity.Create(6973832320392714L); Identity.Create("OID/VAL/Assets") ]
+
+    // Act
+    let! res = readClient.DataSets.RetrieveAsync<DataSetWithoutMetadata> ids
+    let len = Seq.length res
+
+    // Assert
+    test <@ len = 2 @>
+    test <@ Seq.forall (fun (e: DataSetWithoutMetadata) -> isNull e.Metadata) res @>
+}
+
+let ``Retrieve data sets by id is OK`` = task {
+    // Arrange
+    let ids = [ 5272329852941732L; 2452112635370053L ]
+
+    // Act
+    let! res = readClient.DataSets.RetrieveAsync ids
+    let len = Seq.length res
+
+    // Assert
+    test <@ len = 2 @>
+}
+
+let ``Retrieve data sets by externalId is OK`` = task {
+    // Arrange
+    let ids = [ "VAL/FILES/PNIDS"; "OID/VAL/Assets" ]
+
+    // Act
+    let! res = readClient.DataSets.RetrieveAsync ids
+    let len = Seq.length res
+
+    // Assert
+    test <@ len = 2 @>
+}

--- a/CogniteSdk/test/fsharp/DataSets.fs
+++ b/CogniteSdk/test/fsharp/DataSets.fs
@@ -3,7 +3,7 @@
 open System
 open System.Collections.Generic
 
-open FSharp.Control.Tasks.V2.ContextInsensitive
+open FSharp.Control.Tasks
 open Swensen.Unquote
 open Oryx
 open Xunit

--- a/Oryx.Cognite/src/Assets.fs
+++ b/Oryx.Cognite/src/Assets.fs
@@ -37,7 +37,7 @@ module Assets =
     /// Retrieves count of assets matching filter
     /// </summary>
     /// <param name="query">The query to use.</param>
-    /// <returns>List of assets matching given filters</returns>
+    /// <returns>Count of assets matching given filters</returns>
     let aggregate (query: AssetQuery) : HttpHandler<unit, int> =
         withLogMessage "Assets:aggregate"
         >=> aggregate query Url

--- a/Oryx.Cognite/src/DataSets.fs
+++ b/Oryx.Cognite/src/DataSets.fs
@@ -25,3 +25,12 @@ module DataSets =
     let create (items: DataSetCreate seq) : HttpHandler<unit, DataSet seq> =
         withLogMessage "DataSets:create"
         >=> create items Url
+
+    /// <summary>
+    /// Retrieves list of data sets matching filter, and a cursor if given limit is exceeded
+    /// </summary>
+    /// <param name="query">The query to use.</param>
+    /// <returns>List of data sets matching given filters and optional cursor</returns>
+    let list (query: DataSetQuery) : HttpHandler<unit, ItemsWithCursor<#DataSet>> =
+        withLogMessage "DataSets:list"
+        >=> list query Url

--- a/Oryx.Cognite/src/DataSets.fs
+++ b/Oryx.Cognite/src/DataSets.fs
@@ -1,0 +1,27 @@
+﻿// Copyright 2020 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Oryx.Cognite
+
+open System
+open System.Net.Http
+
+open Oryx
+open Oryx.Cognite
+
+open System.Collections.Generic
+open CogniteSdk
+
+[<RequireQualifiedAccess>]
+module DataSets =
+    [<Literal>]
+    let Url = "/datasets"
+
+    /// <summary>
+    /// Create new data sets in the given project.
+    /// </summary>
+    /// <param name="assets">The data sets to create.</param>
+    /// <returns>List of created data sets.</returns>
+    let create (items: DataSetCreate seq) : HttpHandler<unit, DataSet seq> =
+        withLogMessage "DataSets:create"
+        >=> create items Url

--- a/Oryx.Cognite/src/DataSets.fs
+++ b/Oryx.Cognite/src/DataSets.fs
@@ -34,3 +34,12 @@ module DataSets =
     let list (query: DataSetQuery) : HttpHandler<unit, ItemsWithCursor<#DataSet>> =
         withLogMessage "DataSets:list"
         >=> list query Url
+
+    /// <summary>
+    /// Retrieves count of data sets matching filter
+    /// </summary>
+    /// <param name="query">The query to use.</param>
+    /// <returns>Count of data sets matching given filters</returns>
+    let aggregate (query: DataSetQuery) : HttpHandler<unit, int> =
+        withLogMessage "DataSets:aggregate"
+        >=> aggregate query Url

--- a/Oryx.Cognite/src/DataSets.fs
+++ b/Oryx.Cognite/src/DataSets.fs
@@ -54,3 +54,13 @@ module DataSets =
     let retrieve (ids: Identity seq) (ignoreUnknownIds: Nullable<bool>) : HttpHandler<unit, #DataSet seq> =
         withLogMessage "DataSets:retrieve"
         >=> retrieveIgnoreUnkownIds ids (Option.ofNullable ignoreUnknownIds) Url
+
+    /// <summary>
+    /// Update one or more data sets. Supports partial updates, meaning that fields omitted from the requests are not changed.
+    /// Returns list of updated data sets.
+    /// </summary>
+    /// <param name="query">Data set updates to perform.</param>
+    /// <returns>List of updated data sets</returns>
+    let update (query: IEnumerable<UpdateItem<DataSet>>) : HttpHandler<unit, #DataSet seq> =
+        withLogMessage "DataSets:update"
+        >=> update query Url

--- a/Oryx.Cognite/src/DataSets.fs
+++ b/Oryx.Cognite/src/DataSets.fs
@@ -43,3 +43,14 @@ module DataSets =
     let aggregate (query: DataSetQuery) : HttpHandler<unit, int> =
         withLogMessage "DataSets:aggregate"
         >=> aggregate query Url
+
+    /// <summary>
+    /// Retrieves information about multiple data sets in the same project. A maximum of 1000 data set IDs may be listed per
+    /// request and all of them must be unique.
+    /// </summary>
+    /// <param name="ids">The ids of the data sets to get.</param>
+    /// <param name="ignoreUnknownIds">Ignore IDs and external IDs that are not found.</param>
+    /// <returns>Data sets with given ids.</returns>
+    let retrieve (ids: Identity seq) (ignoreUnknownIds: Nullable<bool>) : HttpHandler<unit, #DataSet seq> =
+        withLogMessage "DataSets:retrieve"
+        >=> retrieveIgnoreUnkownIds ids (Option.ofNullable ignoreUnknownIds) Url

--- a/Oryx.Cognite/src/Oryx.Cognite.fsproj
+++ b/Oryx.Cognite/src/Oryx.Cognite.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="Files.fs" />
     <Compile Include="Sequences.fs" />
     <Compile Include="Login.fs" />
+    <Compile Include="DataSets.fs" />
     <Compile Include="Playground/Handler.fs" />
     <Compile Include="Playground/Functions.fs" />
     <Compile Include="Beta/Handler.fs" />


### PR DESCRIPTION
Support for the data sets API. Tests might be difficult to do, since there is no way to delete data sets. Filling the test tenant up with dead data sets isn't ideal.

Tests have been created for read only, using the existing data sets in publicdata. It might be possible to create tests for updates, but create won't be ideal since it is impossible to clean up after creating a new dataset.