### PR TITLE
Make Identity equality comparable

### DIFF
--- a/CogniteSdk.Types/Common/Identity.cs
+++ b/CogniteSdk.Types/Common/Identity.cs
@@ -98,5 +98,29 @@ namespace CogniteSdk {
                 return $"{{ ExternalId = \"{ExternalId}\" }}";
             }
         }
+
+        /// <summary>
+        /// Return true if <paramref name="obj"/> is another, identitical Identity.
+        /// </summary>
+        /// <param name="obj">Object to compare</param>
+        /// <returns>True if equal, false otherwise</returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj)) return true;
+
+            if (!(obj is Identity other)) return false;
+
+            if (Id.HasValue) return Id == other.Id;
+            else return !other.Id.HasValue && ExternalId == other.ExternalId;
+        }
+
+        /// <summary>
+        /// Returns a hashcode representing this Identity.
+        /// </summary>
+        /// <returns>Hashcode representing this</returns>
+        public override int GetHashCode()
+        {
+            return Id.HasValue ? Id.GetHashCode() : ExternalId?.GetHashCode() ?? 0;
+        }
     }
 }

--- a/CogniteSdk.Types/Common/Identity.cs
+++ b/CogniteSdk.Types/Common/Identity.cs
@@ -106,12 +106,22 @@ namespace CogniteSdk {
         /// <returns>True if equal, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(this, obj)) return true;
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
 
-            if (!(obj is Identity other)) return false;
+            if (!(obj is Identity other))
+            {
+                return false;
+            }
 
-            if (Id.HasValue) return Id == other.Id;
-            else return !other.Id.HasValue && ExternalId == other.ExternalId;
+            if (Id.HasValue)
+            {
+                return Id == other.Id;
+            }
+           
+            return !other.Id.HasValue && ExternalId == other.ExternalId;
         }
 
         /// <summary>


### PR DESCRIPTION
This is a pretty common use case, and passing around comparers is bothersome and error-prone.

We have dictionaries with Identities fairly frequently in the .NET utils, and thus far we've been using an IEqualityComparer, but that sometimes requires the user to be aware of this internal detail, and in general just causes avoidable issues.