### PR TITLE
Gzip datapoints support

### DIFF
--- a/CogniteSdk/src/Resources/DataPoints.cs
+++ b/CogniteSdk/src/Resources/DataPoints.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -55,6 +56,27 @@ namespace CogniteSdk.Resources
             }
 
             var req = Oryx.Cognite.DataPoints.create(points);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
+        
+        /// <summary>
+        /// Create data points, applying Gzip compression at level <paramref name="compression"/>.
+        /// </summary>
+        /// <param name="points">Data Points to create</param>
+        /// <param name="compression">Compression level</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>Empty response</returns>
+        public async Task<EmptyResponse> CreateWithGzipAsync(
+            DataPointInsertionRequest points,
+            CompressionLevel compression,
+            CancellationToken token = default)
+        {
+            if (points is null)
+            {
+                throw new ArgumentNullException(nameof(points));
+            }
+
+            var req = Oryx.Cognite.DataPoints.createWithGzip(points, compression);
             return await RunAsync(req, token).ConfigureAwait(false);
         }
 

--- a/CogniteSdk/src/Resources/DataPoints.cs
+++ b/CogniteSdk/src/Resources/DataPoints.cs
@@ -66,7 +66,7 @@ namespace CogniteSdk.Resources
         /// <param name="compression">Compression level</param>
         /// <param name="token">Optional cancellation token.</param>
         /// <returns>Empty response</returns>
-        public async Task<EmptyResponse> CreateWithGzipAsync(
+        public async Task<EmptyResponse> CreateAsync(
             DataPointInsertionRequest points,
             CompressionLevel compression,
             CancellationToken token = default)

--- a/CogniteSdk/test/fsharp/DataPoints.fs
+++ b/CogniteSdk/test/fsharp/DataPoints.fs
@@ -246,7 +246,7 @@ let ``Insert datapoints is Ok`` () = task {
     // Act
     let! _ = writeClient.TimeSeries.CreateAsync [ dto ]
     let! _ = writeClient.DataPoints.CreateAsync points
-    let! _ = writeClient.DataPoints.CreateWithGzipAsync (points, System.IO.Compression.CompressionLevel.Fastest)
+    let! _ = writeClient.DataPoints.CreateAsync (points, System.IO.Compression.CompressionLevel.Fastest)
     let! _ = writeClient.TimeSeries.DeleteAsync [ externalIdString ]
 
     ()

--- a/CogniteSdk/test/fsharp/DataPoints.fs
+++ b/CogniteSdk/test/fsharp/DataPoints.fs
@@ -246,6 +246,7 @@ let ``Insert datapoints is Ok`` () = task {
     // Act
     let! _ = writeClient.TimeSeries.CreateAsync [ dto ]
     let! _ = writeClient.DataPoints.CreateAsync points
+    let! _ = writeClient.DataPoints.CreateWithGzipAsync (points, System.IO.Compression.CompressionLevel.Fastest)
     let! _ = writeClient.TimeSeries.DeleteAsync [ externalIdString ]
 
     ()

--- a/Oryx.Cognite/src/DataPoints.fs
+++ b/Oryx.Cognite/src/DataPoints.fs
@@ -11,6 +11,7 @@ open Oryx
 open Oryx.Cognite
 
 open CogniteSdk
+open System.IO.Compression
 
 
 /// Various time series data points HTTP handlers
@@ -34,6 +35,10 @@ module DataPoints =
     let create (items: DataPointInsertionRequest) : IHttpHandler<unit, EmptyResponse> =
         withLogMessage "DataPoints:create"
         >=> createProtobuf items Url
+
+    let createWithGzip (items: DataPointInsertionRequest) (compression: CompressionLevel) : IHttpHandler<unit, EmptyResponse> =
+        withLogMessage "DataPoints:create"
+        >=> createGzipProtobuf items compression Url
 
     /// Delete data points from 1 or more (multiple) time series.
     let delete (items: DataPointsDelete) : IHttpHandler<unit, EmptyResponse> =

--- a/Oryx.Cognite/src/DataPoints.fs
+++ b/Oryx.Cognite/src/DataPoints.fs
@@ -4,15 +4,13 @@
 namespace Oryx.Cognite
 
 open System.Collections.Generic
-open System.Net.Http
+open System.IO.Compression
 
 open Com.Cognite.V1.Timeseries.Proto
 open Oryx
 open Oryx.Cognite
 
 open CogniteSdk
-open System.IO.Compression
-
 
 /// Various time series data points HTTP handlers
 

--- a/Oryx.Cognite/src/GZip.fs
+++ b/Oryx.Cognite/src/GZip.fs
@@ -1,12 +1,13 @@
 ﻿namespace Oryx.Cognite
 
-open Google.Protobuf
 open System.Net.Http
 open System.Net.Http.Headers
 open System.Threading.Tasks
 open System.IO
 open System.Net
 open System.IO.Compression
+
+open Google.Protobuf
 
 [<AutoOpen>]
 module GZip =

--- a/Oryx.Cognite/src/GZip.fs
+++ b/Oryx.Cognite/src/GZip.fs
@@ -1,0 +1,26 @@
+﻿namespace Oryx.Cognite
+
+open Google.Protobuf
+open System.Net.Http
+open System.Net.Http.Headers
+open System.Threading.Tasks
+open System.IO
+open System.Net
+open System.IO.Compression
+
+[<AutoOpen>]
+module GZip =
+    type GZipProtobufStreamContent (content: IMessage, compression: CompressionLevel) =
+        inherit HttpContent ()
+        let _content = content
+        let _compression = compression
+        do base.Headers.ContentType <- MediaTypeHeaderValue "application/protobuf"
+        do base.Headers.ContentEncoding.Add "gzip"
+
+        override this.SerializeToStreamAsync(stream: Stream, context: TransportContext) : Task =
+            let gzipStream = new GZipStream(stream, _compression)
+            content.WriteTo gzipStream |> Task.FromResult :> _
+
+        override this.TryComputeLength(length: byref<int64>) : bool =
+            length <- -1L
+            false

--- a/Oryx.Cognite/src/GZip.fs
+++ b/Oryx.Cognite/src/GZip.fs
@@ -18,7 +18,7 @@ module GZip =
         do base.Headers.ContentEncoding.Add "gzip"
 
         override this.SerializeToStreamAsync(stream: Stream, context: TransportContext) : Task =
-            let gzipStream = new GZipStream(stream, _compression)
+            use gzipStream = new GZipStream(stream, _compression, true)
             content.WriteTo gzipStream |> Task.FromResult :> _
 
         override this.TryComputeLength(length: byref<int64>) : bool =

--- a/Oryx.Cognite/src/Handler.fs
+++ b/Oryx.Cognite/src/Handler.fs
@@ -10,8 +10,10 @@ open System.Net.Http
 open System.Text.Json
 open System.Threading
 open System.Threading.Tasks
+open System.IO.Compression
 
 open FSharp.Control.Tasks
+open Google.Protobuf
 
 open Oryx
 open Oryx.SystemTextJson
@@ -22,8 +24,6 @@ open Oryx.Protobuf.ResponseReader
 open Oryx.Cognite
 
 open CogniteSdk
-open Google.Protobuf
-open System.IO.Compression
 
 /// Oryx HTTP handlers for specific use within the Cognite SDK
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]

--- a/Oryx.Cognite/src/Oryx.Cognite.fsproj
+++ b/Oryx.Cognite/src/Oryx.Cognite.fsproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common.fs" />
+    <Compile Include="GZip.fs" />
     <Compile Include="Handler.fs" />
     <Compile Include="3D.fs" />
     <Compile Include="Assets.fs" />

--- a/playground/csharp/Program.cs
+++ b/playground/csharp/Program.cs
@@ -5,13 +5,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Diagnostics;
 
 using Com.Cognite.V1.Timeseries.Proto;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using CogniteSdk;
-using System.Diagnostics;
 
 namespace csharp {
 
@@ -149,7 +149,7 @@ namespace csharp {
 
                 var sw = new Stopwatch();
                 sw.Start();
-                await client.DataPoints.CreateWithGzipAsync(data, System.IO.Compression.CompressionLevel.Fastest);
+                await client.DataPoints.CreateAsync(data, System.IO.Compression.CompressionLevel.Fastest);
                 sw.Stop();
                 Console.WriteLine($"Inserting {pair.Item2} datapoints for {pair.Item1} timeseries took {sw.ElapsedMilliseconds} ms");
             }

--- a/playground/csharp/Program.cs
+++ b/playground/csharp/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using CogniteSdk;
+using System.Diagnostics;
 
 namespace csharp {
 
@@ -104,6 +105,92 @@ namespace csharp {
             services.AddLogging(configure => configure.AddConsole().SetMinimumLevel(LogLevel.Debug));
         }
 
+        static async Task GzipPerformanceTest(Client client)
+        {
+            try
+            {
+                var ts = await client.TimeSeries.CreateAsync(
+                    Enumerable.Range(0, 100).Select(idx => new TimeSeriesCreate
+                    {
+                        Name = $"gzip-ts-test-{idx}",
+                        ExternalId = $"gzip-ts-test-{idx}"
+                    }).ToList());
+            } catch (ResponseException rex) when (rex.Duplicated?.Any() ?? false) { }
+
+            var chunks = new[]
+            {
+                (1, 100), (10, 100), (100, 100), (1, 1000), (10, 1000), (100, 1000), (1, 10000), (10, 10000)
+            };
+
+
+            Console.WriteLine("Gzip: ");
+
+            long start = new DateTimeOffset(DateTime.UtcNow).ToUnixTimeMilliseconds();
+            foreach (var pair in chunks)
+            {
+                var data = new DataPointInsertionRequest();
+                for (int i = 0; i < pair.Item1; i++)
+                {
+                    var req = new NumericDatapoints();
+                    for (int j = 0; j < pair.Item2; j++)
+                    {
+                        req.Datapoints.Add(new NumericDatapoint
+                        {
+                            Timestamp = start + i * pair.Item2 + j,
+                            Value = i * pair.Item2 + j
+                        });
+                    }
+                    data.Items.Add(new DataPointInsertionItem
+                    {
+                        ExternalId = $"gzip-ts-test-{i}",
+                        NumericDatapoints = req
+                    });
+                }
+
+                var sw = new Stopwatch();
+                sw.Start();
+                await client.DataPoints.CreateWithGzipAsync(data, System.IO.Compression.CompressionLevel.Fastest);
+                sw.Stop();
+                Console.WriteLine($"Inserting {pair.Item2} datapoints for {pair.Item1} timeseries took {sw.ElapsedMilliseconds} ms");
+            }
+
+            Console.Write("Non-gzip:");
+
+            foreach (var pair in chunks)
+            {
+                var data = new DataPointInsertionRequest();
+                for (int i = 0; i < pair.Item1; i++)
+                {
+                    var req = new NumericDatapoints();
+                    for (int j = 0; j < pair.Item2; j++)
+                    {
+                        req.Datapoints.Add(new NumericDatapoint
+                        {
+                            Timestamp = start + i * pair.Item2 + j,
+                            Value = i * pair.Item2 + j
+                        });
+                    }
+                    data.Items.Add(new DataPointInsertionItem
+                    {
+                        ExternalId = $"gzip-ts-test-{i}",
+                        NumericDatapoints = req
+                    });
+                }
+
+                var sw = new Stopwatch();
+                sw.Start();
+                await client.DataPoints.CreateAsync(data);
+                sw.Stop();
+                Console.WriteLine($"Inserting {pair.Item2} datapoints for {pair.Item1} timeseries took {sw.ElapsedMilliseconds} ms");
+            }
+
+            await client.TimeSeries.DeleteAsync(new TimeSeriesDelete
+            {
+                IgnoreUnknownIds = true,
+                Items = Enumerable.Range(0, 100).Select(idx => Identity.Create($"gzip-ts-test-{idx}"))
+            });
+        }
+
         private static async Task Main() {
             Console.WriteLine("C# Client");
 
@@ -132,9 +219,10 @@ namespace csharp {
                     .SetLogLevel(LogLevel.Debug)
                     .Build();
 
-            var asset = await GetAssetsExample(client, "23-TE-96116-04").ConfigureAwait(false);
-            Console.WriteLine($"{asset}");
-            //var data = await QueryTimeseriesDataExample(client);
+            // var asset = await GetAssetsExample(client, "23-TE-96116-04").ConfigureAwait(false);
+            // Console.WriteLine($"{asset}");
+            // var data = await QueryTimeseriesDataExample(client);
+            await GzipPerformanceTest(client);
         }
     }
 }


### PR DESCRIPTION
GZip support when writing datapoints. It is a separate method with a "CompressionLevel" parameter.

The simple code used for testing performance improvements is added to the C# playground project. The cutoff is around 10k numeric datapoints, the number would be different and more difficult to pin down for string datapoints. At the maximum chunk size of 100k datapoints the response time is improved 2-3 times.