### PR TITLE
Add DataSet ID to 3D Model update

### DIFF
--- a/CogniteSdk.Types/3D/3DModelUpdate.cs
+++ b/CogniteSdk.Types/3D/3DModelUpdate.cs
@@ -14,6 +14,11 @@ namespace CogniteSdk
         /// Set a new value for the string.
         /// </summary>
         public Update<string> Name { get; set; }
+        
+        /// <summary>
+        /// Set a new value for the long, or remove the value.
+        /// </summary>
+        public UpdateNullable<long?> DataSetId { get; set; }
 
         /// <summary>
         /// Custom, application specific metadata. String key -> String value. Limits: Maximum length of key is 32


### PR DESCRIPTION
Missed adding update fields to sdk according to documentation
https://docs.cognite.com/api/v1/#operation/update3DModels