### PR TITLE
Groups support

### DIFF
--- a/CogniteSdk.Types/Groups/Acls.cs
+++ b/CogniteSdk.Types/Groups/Acls.cs
@@ -27,6 +27,11 @@ namespace CogniteSdk
         /// When calling token/inspect this contains the list of projects the current capability is scoped for.
         /// </summary>
         public IEnumerable<string> ProjectsScope { get; set; }
+        /// <summary>
+        /// The name of the capability as read from CDF, useful if there is no type for the capability
+        /// in the SDK.
+        /// </summary>
+        public string CapabilityName { get; set; }
     }
 
     /// <summary>
@@ -234,6 +239,7 @@ namespace CogniteSdk
                 type = typeof(BaseAcl);
             }
             var result = (BaseAcl)Activator.CreateInstance(type);
+            result.CapabilityName = aclName;
 
             while (reader.Read())
             {

--- a/CogniteSdk.Types/Groups/Acls.cs
+++ b/CogniteSdk.Types/Groups/Acls.cs
@@ -72,6 +72,17 @@ namespace CogniteSdk
     }
 
     /// <summary>
+    /// Class wrapping tables in DbsToTables in the raw table scope
+    /// </summary>
+    public class RawTableScopeWrapper
+    {
+        /// <summary>
+        /// List of tables for this database
+        /// </summary>
+        public IEnumerable<string> Tables { get; set; }
+    }
+
+    /// <summary>
     /// Scope for restricting access based on raw databases and tables.
     /// </summary>
     public class RawTableScope
@@ -79,7 +90,7 @@ namespace CogniteSdk
         /// <summary>
         /// Map from database to list of tables.
         /// </summary>
-        public Dictionary<string, IEnumerable<string>> DbsToTables { get; set; }
+        public IDictionary<string, RawTableScopeWrapper> DbsToTables { get; set; }
     }
     /// <summary>
     /// Scope for restricting access based on raw databases and tables.

--- a/CogniteSdk.Types/Groups/Acls.cs
+++ b/CogniteSdk.Types/Groups/Acls.cs
@@ -1,0 +1,402 @@
+﻿// Copyright 2021 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// Basic ACL class with a list of actions
+    /// </summary>
+    public class BaseAcl
+    {
+        /// <summary>
+        /// List of actions. Valid values depend on resource type
+        /// </summary>
+        public IEnumerable<string> Actions { get; set; }
+    }
+
+    /// <summary>
+    /// Base generic ACL class with scope and list of actions.
+    /// </summary>
+    /// <typeparam name="TScope">Type of scope</typeparam>
+    public class BaseAcl<TScope> : BaseAcl where TScope : BaseScope
+    {
+        /// <summary>
+        /// Scope for the resource Acl.
+        /// </summary>
+        public TScope Scope { get; set; }
+    }
+
+    /// <summary>
+    /// Empty object for scopes.
+    /// </summary>
+    public class EmptyScope
+    {
+    }
+
+    /// <summary>
+    /// Base scope class, with all scope, which is common to all resource types.
+    /// </summary>
+    public class BaseScope
+    {
+        /// <summary>
+        /// If set, user has unscoped access to the resource.
+        /// </summary>
+        public EmptyScope All { get; set; }
+    }
+
+    /// <summary>
+    /// Scope containing a list of ids to some other resource.
+    /// </summary>
+    public class IdScope
+    {
+        /// <summary>
+        /// List of internal ids for some other resource.
+        /// </summary>
+        public IEnumerable<long> Ids { get; set; }
+    }
+
+    /// <summary>
+    /// Scope for restricting access based on raw databases and tables.
+    /// </summary>
+    public class RawTableScope
+    {
+        /// <summary>
+        /// Map from database to list of tables.
+        /// </summary>
+        public Dictionary<string, IEnumerable<string>> DbsToTables { get; set; }
+    }
+    /// <summary>
+    /// Scope for restricting access based on raw databases and tables.
+    /// </summary>
+    public class WithRawTableScope : BaseScope
+    {
+        /// <summary>
+        /// Collection of allowed databases with tables.
+        /// </summary>
+        public RawTableScope TableScope { get; set; }
+    }
+
+    /// <summary>
+    /// Scope for restricting access based on asset root ids.
+    /// </summary>
+    public class RootIdsScope
+    {
+        /// <summary>
+        /// List of root asset internal ids.
+        /// </summary>
+        public IEnumerable<long> RootIds { get; set; }
+    }
+
+    /// <summary>
+    /// Scope containing "idscope", restricting access based on internalIds for some other resource.
+    /// </summary>
+    public class WithIdScope : BaseScope
+    {
+        /// <summary>
+        /// Restrict access based on internal ids for some other resource.
+        /// </summary>
+        [JsonPropertyName("idscope")]
+        public IdScope IdScope { get; set; }
+    }
+
+    /// <summary>
+    /// Scope with current user object.
+    /// </summary>
+    public class WithCurrentUserScope : BaseScope
+    {
+        /// <summary>
+        /// Scope access to current user.
+        /// </summary>
+        [JsonPropertyName("currentuserscope")]
+        public EmptyScope CurrentUserScope { get; set; }
+    }
+
+    /// <summary>
+    /// Scope object with list of data set ids.
+    /// </summary>
+    public class WithDataSetsScope : BaseScope
+    {
+        /// <summary>
+        /// Restrict access based on list of data set ids.
+        /// </summary>
+        public IdScope DatasetScope { get; set; }
+    }
+
+    /// <summary>
+    /// Scope access based on list of internal ids or data set ids.
+    /// </summary>
+    public class WithIdAndDatasetScope : WithIdScope
+    {
+        /// <summary>
+        /// Restrict access based on list of data set ids.
+        /// </summary>
+        public IdScope DatasetScope { get; set; }
+    }
+
+    /// <summary>
+    /// JsonConverter for generic Acl objects.
+    /// </summary>
+    public class AclConverter : JsonConverter<BaseAcl>
+    {
+
+        private static readonly IDictionary<string, Type> _aclTypes = new Dictionary<string, Type>
+        {
+            { "groupsAcl", typeof(GroupsAcl) },
+            { "assetsAcl", typeof(AssetsAcl) },
+            { "eventsAcl", typeof(EventsAcl) },
+            { "filesAcl", typeof(FilesAcl) },
+            { "usersAcl", typeof(UsersAcl) },
+            { "projectsAcl", typeof(ProjectsAcl) },
+            { "securityCategoriesAcl", typeof(SecurityCategoriesAcl) },
+            { "rawAcl", typeof(RawAcl) },
+            { "timeSeriesAcl", typeof(TimeSeriesAcl) },
+            { "apikeysAcl", typeof(ApiKeysAcl) },
+            { "threedAcl", typeof(ThreedAcl) },
+            { "sequencesAcl", typeof(SequencesAcl) },
+            { "labelsAcl", typeof(LabelsAcl) },
+            { "analyticsAcl", typeof(AnalyticsAcl) },
+            { "digitalTwinAcl", typeof(DigitalTwinAcl) },
+            { "relationshipsAcl", typeof(RelationshipsAcl) },
+            { "datasetsAcl", typeof(DatasetsAcl) },
+            { "seismicAcl", typeof(SeismicAcl) },
+            { "typesAcl", typeof(TypesAcl) },
+            { "modelHostingAcl", typeof(ModelHostingAcl) },
+            { "functionsAcl", typeof(FunctionsAcl) },
+            { "extractionPipelinesAcl", typeof(ExtPipesAcl) },
+            { "extractionRunsAcl", typeof(ExtPipeRunsAcl) }
+        };
+
+        private static readonly IDictionary<Type, string> _aclNames = new Dictionary<Type, string>();
+
+        static AclConverter()
+        {
+            foreach (var kvp in _aclTypes)
+            {
+                _aclNames[kvp.Value] = kvp.Key;
+            }
+        }
+
+        /// <summary>
+        /// Deserialize an acl object. This removes one layer of nesting, for convenience.
+        /// </summary>
+        /// <param name="reader">JsonReader</param>
+        /// <param name="typeToConvert">Type to convert</param>
+        /// <param name="options">Json serializer options</param>
+        /// <returns>Subtype of <see cref="BaseAcl"/></returns>
+        /// <exception cref="JsonException">If the input is not a valid Acl object</exception>
+        public override BaseAcl Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException($"JsonTokenType was of type {reader.TokenType}, must be StartObject");
+            }
+
+            reader.Read();
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Missing required acl property");
+            }
+
+            var aclName = reader.GetString();
+
+            if (!aclName.EndsWith("acl", StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new JsonException("Missing required acl property");
+            }
+
+            reader.Read();
+
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Missing required acl property");
+            }
+
+            BaseAcl result;
+
+            if (_aclTypes.TryGetValue(aclName.ToLowerInvariant(), out var type))
+            {
+                result = JsonSerializer.Deserialize(ref reader, type, options) as BaseAcl;
+            }
+            else
+            {
+                result = JsonSerializer.Deserialize<BaseAcl>(ref reader, options);
+            }
+
+            reader.Read();
+
+            if (reader.TokenType != JsonTokenType.EndObject)
+            {
+                throw new JsonException("Expected end of object after acl");
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Serialize an acl object.
+        /// </summary>
+        /// <param name="writer">Writer to write to</param>
+        /// <param name="value">Object to write</param>
+        /// <param name="options">Json serializer options</param>
+        public override void Write(Utf8JsonWriter writer, BaseAcl value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+
+            var type = value.GetType();
+            var name = _aclNames[type];
+
+            writer.WritePropertyName(name);
+
+            JsonSerializer.Serialize(writer, value, type, options);
+
+            writer.WriteEndObject();
+        }
+    }
+
+    /// <summary>
+    /// Acl for access to the groups resource. 
+    /// </summary>
+    public class GroupsAcl : BaseAcl<WithCurrentUserScope> { }
+    
+    /// <summary>
+    /// Acl for access to the assets resource.
+    /// </summary>
+    public class AssetsAcl : BaseAcl<WithDataSetsScope> { }
+
+    /// <summary>
+    /// Acl for access to the events resource.
+    /// </summary>
+    public class EventsAcl : BaseAcl<WithDataSetsScope> { }
+
+    /// <summary>
+    /// Acl for access to the files resource.
+    /// </summary>
+    public class FilesAcl : BaseAcl<WithDataSetsScope> { }
+
+    /// <summary>
+    /// Acl for access to the users resource.
+    /// </summary>
+    public class UsersAcl : BaseAcl<WithCurrentUserScope> { }
+
+    /// <summary>
+    /// Acl for access to the projects resource.
+    /// </summary>
+    public class ProjectsAcl : BaseAcl<BaseScope> { }
+
+    /// <summary>
+    /// Acl for access to the security categories resource.
+    /// </summary>
+    public class SecurityCategoriesAcl : BaseAcl<WithIdScope> { }
+
+    /// <summary>
+    /// Acl for access to the raw resource.
+    /// </summary>
+    public class RawAcl : BaseAcl<WithRawTableScope> { }
+
+    /// <summary>
+    /// Scope for access to timeseries.
+    /// </summary>
+    public class TimeSeriesScope : WithIdScope
+    {
+        /// <summary>
+        /// Restrict access based on list of root asset ids for associated assets.
+        /// </summary>
+        public RootIdsScope AssetRootIdScope { get; set; }
+        /// <summary>
+        /// Restrict access based on datasets.
+        /// </summary>
+        public IdScope DatasetScope { get; set; }
+    }
+    /// <summary>
+    /// Acl for access to the timeseries resource.
+    /// </summary>
+    public class TimeSeriesAcl : BaseAcl<TimeSeriesScope> { }
+
+    /// <summary>
+    /// Acl for access to the api keys resource.
+    /// </summary>
+    public class ApiKeysAcl : BaseAcl<WithIdScope> { }
+
+    /// <summary>
+    /// Acl for access to the 3d resource.
+    /// </summary>
+    public class ThreedAcl : BaseAcl<BaseScope> { }
+
+    /// <summary>
+    /// Acl for access to the sequences resource.
+    /// </summary>
+    public class SequencesAcl : BaseAcl<WithDataSetsScope> { }
+
+    /// <summary>
+    /// Acl for access to the labels resource.
+    /// </summary>
+    public class LabelsAcl : BaseAcl<WithDataSetsScope> { }
+
+    /// <summary>
+    /// Acl for access to the analytics resource.
+    /// </summary>
+    public class AnalyticsAcl : BaseAcl<BaseScope> { }
+
+    /// <summary>
+    /// Acl for access to the digital twin resource.
+    /// </summary>
+    public class DigitalTwinAcl : BaseAcl<BaseScope> { }
+
+    /// <summary>
+    /// Acl for access to the relationships resource.
+    /// </summary>
+    public class RelationshipsAcl : BaseAcl<WithDataSetsScope> { }
+
+    /// <summary>
+    /// Acl for access to the datasets resource.
+    /// </summary>
+    public class DatasetsAcl : BaseAcl<WithIdScope> { }
+
+    /// <summary>
+    /// Acl for access to the seismic resource.
+    /// </summary>
+    public class SeismicAcl : BaseAcl<BaseScope> { }
+
+    /// <summary>
+    /// Acl for access to the types resource.
+    /// </summary>
+    public class TypesAcl : BaseAcl<BaseScope> { }
+
+    /// <summary>
+    /// Acl for access to the model hosting resource.
+    /// </summary>
+    public class ModelHostingAcl : BaseAcl<BaseScope> { }
+
+    /// <summary>
+    /// Acl for access to the functions resource.
+    /// </summary>
+    public class FunctionsAcl : BaseAcl<BaseScope> { }
+
+    /// <summary>
+    /// Acl for access to the extraction pipelines resource.
+    /// </summary>
+    public class ExtPipesAcl : BaseAcl<WithIdAndDatasetScope> { }
+
+    /// <summary>
+    /// Scope for access to the extraction pipeline runs resource.
+    /// </summary>
+    public class ExtPipeRunsScope : WithDataSetsScope
+    {
+        /// <summary>
+        /// Scope by list of extraction pipeline internal ids.
+        /// </summary>
+        [JsonPropertyName("extractionpipelinescope")]
+        public IdScope ExtractionPipelineScope { get; set; }
+    }
+
+    /// <summary>
+    /// Acl for access to the extraction pipeline runs resource.
+    /// </summary>
+    public class ExtPipeRunsAcl : BaseAcl<ExtPipeRunsScope> { }
+}

--- a/CogniteSdk.Types/Groups/Acls.cs
+++ b/CogniteSdk.Types/Groups/Acls.cs
@@ -179,23 +179,6 @@ namespace CogniteSdk
             return prop.Name;
         }
 
-        // Skip arbitrary json element
-        private void SkipJsonElement(ref Utf8JsonReader reader)
-        {
-            int sObj = 0, sArr = 0;
-
-            do
-            {
-                if (!reader.Read()) break;
-
-                if (reader.TokenType == JsonTokenType.StartObject) sObj++;
-                if (reader.TokenType == JsonTokenType.EndObject) sObj--;
-                if (reader.TokenType == JsonTokenType.StartArray) sArr++;
-                if (reader.TokenType == JsonTokenType.EndArray) sArr--;
-
-            } while (sObj > 0 || sArr > 0);
-        }
-
         private void ReadScope(ref Utf8JsonReader reader, BaseAcl acl, JsonSerializerOptions options)
         {
             reader.Read();
@@ -231,8 +214,7 @@ namespace CogniteSdk
 
                 if (!propFound)
                 {
-                    // Unknown capability type, skip scope
-                    SkipJsonElement(ref reader);
+                    reader.Skip();
                 }
             }
         }
@@ -272,7 +254,7 @@ namespace CogniteSdk
                 }
                 else
                 {
-                    SkipJsonElement(ref reader);
+                    reader.Skip();
                 }
             }
 
@@ -318,7 +300,7 @@ namespace CogniteSdk
                 }
                 else
                 {
-                    SkipJsonElement(ref reader);
+                    reader.Skip();
                 }
             }
 

--- a/CogniteSdk.Types/Groups/Group.cs
+++ b/CogniteSdk.Types/Groups/Group.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2021 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// CDF Group object, contains a list of capabilities.
+    /// </summary>
+    public class Group
+    {
+        /// <summary>
+        /// Name of the group.
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// ID of the group in the source. 
+        /// If this is the same ID as a group in the IdP,
+        /// a service account in that group will implicitly be a part of this group as well.
+        /// </summary>
+        public string SourceId { get; set; }
+        /// <summary>
+        /// List of capabilities for this group.
+        /// </summary>
+        public IEnumerable<BaseAcl> Capabilities { get; set; }
+        /// <summary>
+        /// Internal id of group.
+        /// </summary>
+        public long Id { get; set; }
+        /// <summary>
+        /// True if this group is deleted.
+        /// </summary>
+        public bool IsDeleted { get; set; }
+        /// <summary>
+        /// Time this group was deleted from the source.
+        /// </summary>
+        public long? DeletedTime { get; set; }
+    }
+}

--- a/CogniteSdk.Types/Groups/GroupCreate.cs
+++ b/CogniteSdk.Types/Groups/GroupCreate.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2021 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// Create a CDF group.
+    /// </summary>
+    public class GroupCreate
+    {
+        /// <summary>
+        /// Name of the group.
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// ID of the group in the source. 
+        /// If this is the same ID as a group in the IdP,
+        /// a service account in that group will implicitly be a part of this group as well.
+        /// </summary>
+        public string SourceId { get; set; }
+        /// <summary>
+        /// List of capabilities for this group.
+        /// </summary>
+        public IEnumerable<BaseAcl> Capabilities { get; set; }
+    }
+}

--- a/CogniteSdk.Types/Groups/GroupDelete.cs
+++ b/CogniteSdk.Types/Groups/GroupDelete.cs
@@ -1,0 +1,12 @@
+﻿// Copyright 2021 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// Delete a list of groups
+    /// </summary>
+    public class GroupDelete : ItemsWithoutCursor<long>
+    {
+    }
+}

--- a/CogniteSdk.Types/Groups/GroupQuery.cs
+++ b/CogniteSdk.Types/Groups/GroupQuery.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2021 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace CogniteSdk
+{
+    /// <summary>
+    /// Query for listing groups
+    /// </summary>
+    public class GroupQuery : IQueryParams
+    {
+        /// <summary>
+        /// True to list all groups. Default is false, which lists only the groups
+        /// the current user is a member of.
+        /// </summary>
+        public bool All { get; set; }
+
+        /// <inheritdoc />
+        public List<(string, string)> ToQueryParams()
+        {
+            var result = new List<(string, string)>();
+            if (All)
+            {
+                result.Add(("all", "true"));
+            }
+            return result;
+        }
+    }
+}

--- a/CogniteSdk.Types/Token/TokenInspect.cs
+++ b/CogniteSdk.Types/Token/TokenInspect.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace CogniteSdk.Token
 {

--- a/CogniteSdk.Types/Token/TokenInspect.cs
+++ b/CogniteSdk.Types/Token/TokenInspect.cs
@@ -21,13 +21,10 @@ namespace CogniteSdk.Token
         /// </summary>
         public IEnumerable<TokenProject> Projects { get; set; }
 
-        // TODO: This can be ignored for now. If the Groups API is implemented,
-        // then the same types can be reused here.
         /// <summary>
         /// List of capabilities associated with the token. 
         /// </summary>
-        [JsonIgnore]
-        public IEnumerable<object> Capabilities { get; set; }
+        public IEnumerable<BaseAcl> Capabilities { get; set; }
     }
 
 }

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -111,6 +111,11 @@ namespace CogniteSdk
         public LabelsResource Labels { get; }
 
         /// <summary>
+        /// Client group extension methods
+        /// </summary>
+        public GroupsResource Groups { get; }
+
+        /// <summary>
         /// Client beta extension methods
         /// </summary>
         public BetaResource Beta { get; }
@@ -139,6 +144,7 @@ namespace CogniteSdk
             Token = new TokenResource(authHandler, ctx);
             ExtPipes = new ExtPipesResource(authHandler, ctx);
             Labels = new LabelsResource(authHandler, ctx);
+            Groups = new GroupsResource(authHandler, ctx);
 
             // Playground features (experimental)
             Playground = new PlaygroundResource(authHandler, ctx);

--- a/CogniteSdk/src/Resources/Groups.cs
+++ b/CogniteSdk/src/Resources/Groups.cs
@@ -1,0 +1,83 @@
+﻿// Copyright 2021 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Oryx;
+
+
+namespace CogniteSdk.Resources
+{
+    /// <summary>
+    /// For internal use. Contains all group methods.
+    /// </summary>
+    public class GroupsResource : Resource
+    {
+        /// <summary>
+        /// The class constructor. Will only be instantiated by the client.
+        /// </summary>
+        /// <param name="authHandler">Authentication handler.</param>
+        /// <param name="ctx">The HTTP context to use for the request.</param>
+        internal GroupsResource(Func<CancellationToken, Task<string>> authHandler, HttpContext ctx) : base(authHandler, ctx)
+        {
+        }
+
+        /// <summary>
+        /// List groups
+        /// </summary>
+        /// <param name="all">True to fetch all groups, false to only fetch those belonging to the current user</param>
+        /// <param name="token">Optional cancellation token</param>
+        /// <returns>List of retrieved groups</returns>
+        public async Task<IEnumerable<Group>> ListAsync(bool all, CancellationToken token = default)
+        {
+            var query = new GroupQuery { All = all };
+
+            var req = Oryx.Cognite.Groups.list(query);
+            var result = await RunAsync(req, token).ConfigureAwait(false);
+            return result.Items;
+        }
+
+        /// <summary>
+        /// List groups, fetching only those belonging to the current user.
+        /// </summary>
+        /// <param name="token">Optional cancellation token</param>
+        /// <returns>List of retrieved groups</returns>
+        public async Task<IEnumerable<Group>> ListAsync(CancellationToken token = default)
+        {
+            return await ListAsync(false, token);
+        }
+
+        /// <summary>
+        /// Create a list of groups in CDF.
+        /// </summary>
+        /// <param name="items">List of groups to create.</param>
+        /// <param name="token">Optional cancellation token</param>
+        /// <returns>List of created groups</returns>
+        public async Task<IEnumerable<Group>> CreateAsync(IEnumerable<GroupCreate> items, CancellationToken token = default)
+        {
+            var req = Oryx.Cognite.Groups.create(items);
+            return await RunAsync(req, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Delete a list of groups by internal id.
+        /// </summary>
+        /// <param name="ids">Internal ids of groups to delete</param>
+        /// <param name="token">Optional cancellation token</param>
+        /// <returns></returns>
+        public async Task DeleteAsync(IEnumerable<long> ids, CancellationToken token = default)
+        {
+            var query = new GroupDelete
+            {
+                Items = ids
+            };
+
+            var req = Oryx.Cognite.Groups.delete(query);
+            await RunAsync(req, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/CogniteSdk/test/fsharp/CogniteSdk.Test.fsproj
+++ b/CogniteSdk/test/fsharp/CogniteSdk.Test.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="DataSets.fs" />
     <Compile Include="Login.fs" />
     <Compile Include="Labels.fs" />
+    <Compile Include="Groups.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/CogniteSdk/test/fsharp/Common.fs
+++ b/CogniteSdk/test/fsharp/Common.fs
@@ -42,8 +42,8 @@ module Common =
 
         createOAuth2SdkClient
             oAuth2AccessToken
-            "fusiondotnet-tests"
-            "https://greenfield.cognitedata.com"
+            "einar-test"
+            "https://api.cognitedata.com"
 
     let noAuthClient =
         let handler = new HttpClientHandler(ServerCertificateCustomValidationCallback = (fun message cert chain errors -> true))

--- a/CogniteSdk/test/fsharp/Common.fs
+++ b/CogniteSdk/test/fsharp/Common.fs
@@ -42,8 +42,8 @@ module Common =
 
         createOAuth2SdkClient
             oAuth2AccessToken
-            "einar-test"
-            "https://api.cognitedata.com"
+            "fusiondotnet-tests"
+            "https://greenfield.cognitedata.com"
 
     let noAuthClient =
         let handler = new HttpClientHandler(ServerCertificateCustomValidationCallback = (fun message cert chain errors -> true))

--- a/CogniteSdk/test/fsharp/Groups.fs
+++ b/CogniteSdk/test/fsharp/Groups.fs
@@ -31,11 +31,12 @@ let ``List all groups is OK`` () = task {
 let ``Create delete group is OK`` () = task {
     // Arrange
     let capabilities : BaseAcl list = [
-        GroupsAcl(Scope=WithCurrentUserScope(CurrentUserScope=EmptyScope()), Actions=["LIST"]);
-        RelationshipsAcl(Scope=WithDataSetsScope(All=EmptyScope()), Actions=["READ"]);
+        GroupsAcl(CurrentUserScope=BaseScope(), Actions=["LIST"]);
+        RelationshipsAcl(All=BaseScope(), Actions=["READ"]);
         RawAcl(
-            Scope=WithRawTableScope(TableScope=RawTableScope(
-                DbsToTables=dict["sdk-test-database", RawTableScopeWrapper(Tables=["sdk-test-table"])])),
+            TableScope=RawTableScope(
+                DbsToTables=dict["sdk-test-database", RawTableScopeWrapper(Tables=["sdk-test-table"])]
+            ),
             Actions=["LIST"]
         )
     ]

--- a/CogniteSdk/test/fsharp/Groups.fs
+++ b/CogniteSdk/test/fsharp/Groups.fs
@@ -40,10 +40,11 @@ let ``Create delete group is OK`` () = task {
             Actions=["LIST"]
         )
     ]
-    let group = GroupCreate(
-        Name = "sdk-test-group",
-        Capabilities=capabilities
-    )
+    let group =
+        GroupCreate(
+            Name = "sdk-test-group",
+            Capabilities=capabilities
+        )
 
     // Act
     let! res = writeClient.Groups.CreateAsync [group]

--- a/CogniteSdk/test/fsharp/Groups.fs
+++ b/CogniteSdk/test/fsharp/Groups.fs
@@ -52,3 +52,12 @@ let ``Create delete group is OK`` () = task {
     // Assert
     test <@ Seq.length res = 1 @>
 }
+
+[<Fact>]
+let ``Token inspect for capabilities is OK`` () = task {
+    // Act
+    let! res = writeClient.Token.InspectAsync ()
+
+    // Assert
+    test <@ Seq.length res.Capabilities > 0 @>
+}

--- a/CogniteSdk/test/fsharp/Groups.fs
+++ b/CogniteSdk/test/fsharp/Groups.fs
@@ -1,0 +1,32 @@
+﻿module Tests.Integration.Groups
+
+open System
+open System.Collections.Generic
+
+open FSharp.Control.Tasks
+open Swensen.Unquote
+open Oryx
+open Xunit
+
+open CogniteSdk
+open Common
+
+[<Fact>]
+let ``List own groups is OK`` () = task {
+    // Act
+    let! res = writeClient.Groups.ListAsync()
+
+    test <@ Seq.length res > 0 @>
+    test <@ Seq.exists (fun (g: Group) ->
+        Seq.exists (fun (cap: BaseAcl) -> cap :? GroupsAcl) g.Capabilities
+    ) res @>
+}
+
+[<Fact>]
+let ``List all groups is OK`` () = task {
+    // Act
+    let! res = writeClient.Groups.ListAsync true
+
+    test <@ Seq.length res > 1 @>
+    test <@ Seq.exists (fun (g: Group) -> g.Name = "admin") res @>
+}

--- a/Oryx.Cognite/src/Common.fs
+++ b/Oryx.Cognite/src/Common.fs
@@ -72,6 +72,7 @@ module Common =
             )
         options.Converters.Add(MultiValueConverter())
         options.Converters.Add(ObjectToDictionaryJsonConverter())
+        options.Converters.Add(AclConverter())
         options
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]

--- a/Oryx.Cognite/src/Groups.fs
+++ b/Oryx.Cognite/src/Groups.fs
@@ -19,7 +19,6 @@ module Groups =
     [<Literal>]
     let Url = "/groups"
 
-
     let list (query: GroupQuery) : IHttpHandler<unit, ItemsWithoutCursor<Group>> =
         withLogMessage "Groups:list"
         >=> getWithQuery query Url

--- a/Oryx.Cognite/src/Groups.fs
+++ b/Oryx.Cognite/src/Groups.fs
@@ -1,0 +1,33 @@
+﻿// Copyright 2021 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Oryx.Cognite
+
+open System
+open System.Net.Http
+
+open Oryx
+open Oryx.Cognite
+
+open System.Collections.Generic
+open CogniteSdk
+
+/// Various asset HTTP handlers.
+
+[<RequireQualifiedAccess>]
+module Groups =
+    [<Literal>]
+    let Url = "/groups"
+
+
+    let list (query: GroupQuery) : IHttpHandler<unit, ItemsWithoutCursor<Group>> =
+        withLogMessage "Groups:list"
+        >=> getWithQuery query Url
+
+    let create (items: GroupCreate seq) : IHttpHandler<unit, Group seq> =
+        withLogMessage "Groups:create"
+        >=> create items Url
+
+    let delete (items: GroupDelete) : IHttpHandler<unit, EmptyResponse> =
+        withLogMessage "Groups:delete"
+        >=> delete items Url

--- a/Oryx.Cognite/src/Oryx.Cognite.fsproj
+++ b/Oryx.Cognite/src/Oryx.Cognite.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="Token.fs" />
     <Compile Include="ExtPipes.fs" />
     <Compile Include="Labels.fs" />
+    <Compile Include="Groups.fs" />
     <Compile Include="Playground/Handler.fs" />
     <Compile Include="Playground/Functions.fs" />
     <Compile Include="Beta/Handler.fs" />

--- a/Oryx.Cognite/src/Token.fs
+++ b/Oryx.Cognite/src/Token.fs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 namespace Oryx.Cognite
 
-open System.Net.Http
-
 open Oryx
 open Oryx.Cognite
 open Oryx.SystemTextJson.ResponseReader


### PR DESCRIPTION
Suggested implementation for supporting groups. I've been looking into this because I'd like to list capabilities in token/inspect. A custom converter is necessary no matter what for properly serializing and deserializing capabilities. In order to make the user interface pleasant, and not plagued by complicated nested objects, I've made a custom converter which takes takes objects on the form

```
class SpecificCapability {
    IEnumerable<string> Actions
    ScopeType1 SomeScope
    ScopeType2 SomeOtherScope
}
```

and converts them to

```
{
    "specificCapability": {
        "actions": [...],
        "scope": {
            "someScope": { ... }
        }
    }
}
```

This required a decent amount of custom converter code.

I'm very open for suggestions for how to do this better, but I've tried multiple approaches, and this gave the best results in my opinion.