### PR TITLE
Use TrySkip instead of Skip

### DIFF
--- a/CogniteSdk.Types/Groups/Acls.cs
+++ b/CogniteSdk.Types/Groups/Acls.cs
@@ -219,7 +219,7 @@ namespace CogniteSdk
 
                 if (!propFound)
                 {
-                    reader.Skip();
+                    if (!reader.TrySkip()) throw new JsonException($"Could not skip property {scopeName}");
                 }
             }
         }
@@ -260,7 +260,7 @@ namespace CogniteSdk
                 }
                 else
                 {
-                    reader.Skip();
+                    if (!reader.TrySkip()) throw new JsonException($"Could not skip property {propertyName}");
                 }
             }
 
@@ -306,7 +306,7 @@ namespace CogniteSdk
                 }
                 else
                 {
-                    reader.Skip();
+                    if (!reader.TrySkip()) throw new JsonException($"Could not skip property {propName}");
                 }
             }
 


### PR DESCRIPTION
This seems stupid, because one would expect Skip() to be `if (!TrySkip()) throw new JsonException()`, but it is _not_. In fact, Skip() fails immediately if the JSON is partial, TrySkip will try to parse the JSON. So if the payload is large enough, Skip() will fail and TrySkip() will not.

See https://github.com/dotnet/runtime/blob/64c05a3bcb4e71ee9972a3fb47eb4d3e061d3462/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs#L303