### PR TITLE
Fix bug serializing ACLs with idscope

### DIFF
--- a/CogniteSdk.Types/Groups/Acls.cs
+++ b/CogniteSdk.Types/Groups/Acls.cs
@@ -85,18 +85,8 @@ namespace CogniteSdk
         /// <summary>
         /// List of internal ids for some other resource.
         /// </summary>
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         public IEnumerable<long> Ids { get; set; }
-    }
-
-    /// <summary>
-    /// Scope containing a list of ids to some other resource, as strings.
-    /// </summary>
-    public class IdScopeString : BaseScope
-    {
-        /// <summary>
-        /// List of internal ids for some other resource.
-        /// </summary>
-        public IEnumerable<string> Ids { get; set; }
     }
 
     /// <summary>
@@ -129,6 +119,7 @@ namespace CogniteSdk
         /// <summary>
         /// List of root asset internal ids.
         /// </summary>
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         public IEnumerable<long> RootIds { get; set; }
     }
 
@@ -400,7 +391,7 @@ namespace CogniteSdk
         /// Restrict access based on internal ids for some other resource.
         /// </summary>
         [JsonPropertyName("idscope")]
-        public IdScopeString IdScope { get; set; }
+        public IdScope IdScope { get; set; }
     }
 
     /// <summary>
@@ -438,7 +429,7 @@ namespace CogniteSdk
         /// Restrict access based on internal ids for some other resource.
         /// </summary>
         [JsonPropertyName("idscope")]
-        public IdScopeString IdScope { get; set; }
+        public IdScope IdScope { get; set; }
     }
 
     /// <summary>

--- a/CogniteSdk/test/fsharp/Groups.fs
+++ b/CogniteSdk/test/fsharp/Groups.fs
@@ -40,12 +40,6 @@ let ``Create delete group is OK`` () = task {
                 DbsToTables=dict["sdk-test-database", RawTableScopeWrapper(Tables=["sdk-test-table"])]
             ),
             Actions=["LIST"]
-        );
-        TimeSeriesAcl(
-            DatasetScope=IdScope(
-                Ids=[ 5272329852941732L; 2452112635370053L ]
-            ),
-            Actions=["READ"]
         )
     ]
     let group =

--- a/CogniteSdk/test/fsharp/Groups.fs
+++ b/CogniteSdk/test/fsharp/Groups.fs
@@ -1,5 +1,7 @@
 ﻿module Tests.Integration.Groups
 
+open System.Text.Json
+
 open FSharp.Control.TaskBuilder
 open Swensen.Unquote
 open Xunit
@@ -38,6 +40,12 @@ let ``Create delete group is OK`` () = task {
                 DbsToTables=dict["sdk-test-database", RawTableScopeWrapper(Tables=["sdk-test-table"])]
             ),
             Actions=["LIST"]
+        );
+        TimeSeriesAcl(
+            DatasetScope=IdScope(
+                Ids=[ 5272329852941732L; 2452112635370053L ]
+            ),
+            Actions=["READ"]
         )
     ]
     let group =
@@ -62,3 +70,41 @@ let ``Token inspect for capabilities is OK`` () = task {
     // Assert
     test <@ Seq.length res.Capabilities > 0 @>
 }
+
+[<Fact>]
+let ``Deserialize, serialize idscope ACL is OK`` () =
+    // Arrange
+    let json = @"{""timeSeriesAcl"":{""actions"":[""READ"",""WRITE""],""scope"":{""idscope"":{""ids"":[""1234"",""4321""]}}}}"
+    // Same, but ids are no longer strings. Groups create handles this fine
+    let excepectedResult = @"{""timeSeriesAcl"":{""actions"":[""READ"",""WRITE""],""scope"":{""idscope"":{""ids"":[1234,4321]}}}}"
+
+    // Act
+    let res = JsonSerializer.Deserialize<BaseAcl>(json, Oryx.Cognite.Common.jsonOptions)
+
+    let acl = 
+        match res with
+        | :? TimeSeriesAcl as acl -> acl
+        | _ -> failwith "Result is not correctly deserialized"
+
+    let baseAcl: BaseAcl = acl
+    let reverse = JsonSerializer.Serialize(baseAcl, Oryx.Cognite.Common.jsonOptions)
+
+    // Assert
+    test <@ reverse = excepectedResult @>
+    test <@ Seq.length acl.IdScope.Ids = 2 @>
+    test <@ Seq.item 0 acl.IdScope.Ids = 1234 @>
+    test <@ Seq.length acl.Actions = 2 @>
+    test <@ Seq.item 0 acl.Actions = "READ" @>
+
+[<Fact>]
+let ``Deserialize unknown ACL is OK`` () =
+    // Arrange
+    let json = @"{""unknownAcl"":{""actions"":[""READ"",""WRITE""],""scope"":{""some-scope"":{""ids"":[""1234"",""4321""]}}}}"
+
+    // Act
+    let res = JsonSerializer.Deserialize<BaseAcl>(json, Oryx.Cognite.Common.jsonOptions)
+
+    // Assert
+    test <@ res.CapabilityName = "unknownAcl" @>
+    test <@ Seq.length res.Actions = 2 @>
+    test <@ Seq.item 0 res.Actions = "READ" @>


### PR DESCRIPTION
Turns out docs is wrong here, and there is probably something funky with how this is done in the auth API itself. IdScope is documented to be (mostly) arrays of integers, but they are generally universally arrays of strings, although the API accepts arrays of integers on groups create.

We solve this by just using integers locally (which is better for the user), and sending integers to the API (since it works, and is technically more compact). There is a convenient attribute in System.Text.Json which handles this for us.

I also added a few tests, to make sure this actually works.