### PR TITLE
Add common interface for queries with partition

### DIFF
--- a/CogniteSdk.Types/Assets/AssetQuery.cs
+++ b/CogniteSdk.Types/Assets/AssetQuery.cs
@@ -9,7 +9,7 @@ namespace CogniteSdk
     /// <summary>
     /// The Asset query class.
     /// </summary>
-    public class AssetQuery : CursorQueryBase
+    public class AssetQuery : CursorQueryBase, IPartitionedQuery
     {
         /// <summary>
         /// Filter on assets with strict matching.

--- a/CogniteSdk.Types/Common/IPartitionedQuery.cs
+++ b/CogniteSdk.Types/Common/IPartitionedQuery.cs
@@ -1,0 +1,17 @@
+﻿// Copyright 2021 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+namespace CogniteSdk.Types.Common
+{
+    /// <summary>
+    /// Interface for queries with the "Partition" parameter, splitting the data set into N partitions.
+    /// </summary>
+    public interface IPartitionedQuery
+    {
+        /// <summary>
+        /// Splits the data set into N partitions. You need to follow the cursors within each partition in order to
+        /// receive all the data. Example: 1/10.
+        /// </summary>
+        string Partition { get; set; }
+    }
+}

--- a/CogniteSdk.Types/Events/EventQuery.cs
+++ b/CogniteSdk.Types/Events/EventQuery.cs
@@ -10,7 +10,7 @@ namespace CogniteSdk
     /// <summary>
     /// The Event query class.
     /// </summary>
-    public class EventQuery : CursorQueryBase
+    public class EventQuery : CursorQueryBase, IPartitionedQuery
     {
         /// <summary>
         /// Filter on assets with strict matching.

--- a/CogniteSdk.Types/Timeseries/TimeSeriesQuery.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesQuery.cs
@@ -8,7 +8,7 @@ namespace CogniteSdk
     /// <summary>
     /// The time series query class.
     /// </summary>
-    public class TimeSeriesQuery : CursorQueryBase
+    public class TimeSeriesQuery : CursorQueryBase, IPartitionedQuery
     {
         /// <summary>
         /// Filter on time series with strict matching.


### PR DESCRIPTION
It is already possible to generalize methods which use ItemsWithCursor and CursorQueryBase. This makes it possible to generalize methods using partitions as well, reducing code duplication.