### PR TITLE
BND3D-1393 change annotation parameter precision from float to double

### DIFF
--- a/CogniteSdk.Types/Annotations/AnnotationData.cs
+++ b/CogniteSdk.Types/Annotations/AnnotationData.cs
@@ -42,7 +42,7 @@ namespace CogniteSdk
         /// <summary>
         /// The homogeneous transformation matrix
         /// </summary>
-        public float[] Matrix {get; set;}
+        public double[] Matrix {get; set;}
     }
     /// <summary>
     /// A cylinder in 3D space, defined by the centers of two sides and the radius.
@@ -51,15 +51,15 @@ namespace CogniteSdk
         /// <summary>
         /// The center of the first cap.
         /// </summary>
-        public float[] CenterA {get; set;}
+        public double[] CenterA {get; set;}
         /// <summary>
         /// The center of the second cap.
         /// </summary>
-        public float[] CenterB {get; set;}
+        public double[] CenterB {get; set;}
         /// <summary>
         /// The radius of the cylinder.
         /// </summary>  
-        public float Radius {get; set;}
+        public double Radius {get; set;}
     }
     /// <summary>
     /// The metadata of a geometric object
@@ -68,7 +68,7 @@ namespace CogniteSdk
         /// <summary>
         /// Mixin that can be used to add confidence score to a thing
         /// </summary> 
-        public float Confidence {get; set;}
+        public double Confidence {get; set;}
         /// <summary>
         /// "Mixin that can be used to add a label string to a thing
         /// </summary> 

--- a/CogniteSdk/test/csharp/Annotations.cs
+++ b/CogniteSdk/test/csharp/Annotations.cs
@@ -53,8 +53,8 @@ namespace Test.CSharp.Integration
                     {
                         Cylinder = new Cylinder()
                         {
-                            CenterA = new float[] {0, 1, 2},
-                            CenterB = new float[] {2, 3, 4},
+                            CenterA = new double[] {0, 1, 2},
+                            CenterB = new double[] {2, 3, 4},
                             Radius = 3
 
                         }
@@ -100,8 +100,8 @@ namespace Test.CSharp.Integration
                     {
                         Cylinder = new Cylinder()
                         {
-                            CenterA = new float[] {0, 1, 2},
-                            CenterB = new float[] {2, 3, 4},
+                            CenterA = new double[] {0, 1, 2},
+                            CenterB = new double[] {2, 3, 4},
                             Radius = 3
 
                         }
@@ -150,7 +150,7 @@ namespace Test.CSharp.Integration
             {
                 Region = new List<Geometry> {
                     new Geometry{Box=new Box {
-                        Matrix = new float[] {0, 1, 2, 3,4,5,6,7,8,9,10,11,12,13,14,15}
+                        Matrix = new double[] {0, 1, 2, 3,4,5,6,7,8,9,10,11,12,13,14,15}
                     }}
                 }
             };


### PR DESCRIPTION
The annotation API actually supports double-precision (`float` in Python) for these parameters. This PR addresses that. 