### PR TITLE
Fix packet conflicts

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ group Sdk
     source https://www.nuget.org/api/v2
     framework: netstandard2.0
 
-    nuget FSharp.Core >= 6 lowest_matching: true
+    nuget FSharp.Core >= 7 lowest_matching: true
     nuget Oryx ~> 5
     nuget FsToolkit.ErrorHandling ~> 4
 
@@ -14,7 +14,7 @@ group Oryx.Cognite
     storage: none
     framework: netstandard2.0
 
-    nuget FSharp.Core >= 6 lowest_matching: true
+    nuget FSharp.Core >= 7 lowest_matching: true
     nuget System.Text.Json >= 6 lowest_matching: true
     nuget CogniteSdk.Protobuf
     nuget Oryx ~> 5
@@ -27,7 +27,7 @@ group CogniteSdk.FSharp
     storage: none
     framework: netstandard2.0
 
-    nuget FSharp.Core >= 6 lowest_matching: true
+    nuget FSharp.Core >= 7 lowest_matching: true
     nuget Oryx ~> 5
     nuget FsToolkit.ErrorHandling ~> 4
 
@@ -35,13 +35,13 @@ group Types
     source https://www.nuget.org/api/v2
     framework: netstandard2.0
 
-    nuget System.Text.Json ~> 6
+    nuget System.Text.Json >= 6 lowest_matching: true
 
 group Test
     source https://www.nuget.org/api/v2
     storage: none
 
-    nuget FSharp.Core >= 6 lowest_matching: true
+    nuget FSharp.Core >= 7 lowest_matching: true
     nuget coverlet.msbuild
     nuget Unquote ~> 6
     nuget xunit ~> 2

--- a/paket.lock
+++ b/paket.lock
@@ -5,7 +5,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (6.0)
+    FSharp.Core (7.0)
     FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
@@ -62,7 +62,7 @@ NUGET
   remote: https://www.nuget.org/api/v2
     CogniteSdk.Protobuf (1.0.4)
       Google.Protobuf (>= 3.19.4)
-    FSharp.Core (6.0)
+    FSharp.Core (7.0)
     FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Google.Protobuf (3.23.1)
@@ -879,7 +879,7 @@ GROUP Sdk
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (6.0)
+    FSharp.Core (7.0)
     FsToolkit.ErrorHandling (4.6)
       FSharp.Core (>= 4.7.2)
     Microsoft.Bcl.AsyncInterfaces (7.0)
@@ -1576,7 +1576,7 @@ NUGET
       System.Buffers (>= 4.5.1)
       System.Memory (>= 4.5.5)
       System.Runtime.CompilerServices.Unsafe (>= 6.0)
-    System.Text.Json (6.0.7)
+    System.Text.Json (6.0)
       Microsoft.Bcl.AsyncInterfaces (>= 6.0)
       System.Buffers (>= 4.5.1)
       System.Memory (>= 4.5.4)


### PR DESCRIPTION
One of the System.Text.Json dependencies wasn't updated, and we need to use FSharp.Core 7, because FsToolkit.ErrorHandling has a hard dependency on FSharp.Core >= 7, and when we set it to 6 here it requires every dependent to also specify a dependency on FSharp.Core.