### PR TITLE
Fix packet conflicts

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -35,7 +35,7 @@ group Types
     source https://www.nuget.org/api/v2
     framework: netstandard2.0
 
-    nuget System.Text.Json ~> 6
+    nuget System.Text.Json >= 6 lowest_matching: true
 
 group Test
     source https://www.nuget.org/api/v2

--- a/paket.lock
+++ b/paket.lock
@@ -1576,7 +1576,7 @@ NUGET
       System.Buffers (>= 4.5.1)
       System.Memory (>= 4.5.5)
       System.Runtime.CompilerServices.Unsafe (>= 6.0)
-    System.Text.Json (6.0.7)
+    System.Text.Json (6.0)
       Microsoft.Bcl.AsyncInterfaces (>= 6.0)
       System.Buffers (>= 4.5.1)
       System.Memory (>= 4.5.4)


### PR DESCRIPTION
One of the System.Text.Json dependencies wasn't updated.

We also need to find a solution to conflicts created by FSharp.Core, though that requires a change to Oryx, I think.