### PR TITLE
[Simulators API] add simulation run create

### DIFF
--- a/CogniteSdk.Types/Alpha/Simulators/SimulationRunCreate.cs
+++ b/CogniteSdk.Types/Alpha/Simulators/SimulationRunCreate.cs
@@ -1,0 +1,26 @@
+// Copyright 2023 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+namespace CogniteSdk.Alpha
+{
+    /// <summary>
+    /// Simulation run to create
+    /// </summary>
+    public class SimulationRunCreate
+    {
+        /// <summary>
+        /// The simulator name
+        /// </summary>
+        public string SimulatorName { get; set; }
+
+        /// <summary>
+        /// The routine name
+        /// </summary>
+        public string RoutineName { get; set; }
+
+        /// <summary>
+        /// The model name
+        /// </summary>
+        public string ModelName { get; set; }
+    }
+}

--- a/CogniteSdk/src/Resources/Alpha/Simulators.cs
+++ b/CogniteSdk/src/Resources/Alpha/Simulators.cs
@@ -33,7 +33,7 @@ namespace CogniteSdk.Resources.Alpha
         /// </summary>
         /// <param name="items">Simulation run items to create</param>
         /// <param name="token">Optional cancellation token</param>
-        /// <returns>All simulation runs in project</returns>
+        /// <returns>A list of created simulation runs</returns>
         public async Task<IEnumerable<SimulationRun>> CreateSimulationRunsAsync(IEnumerable<SimulationRunCreate> items, CancellationToken token = default)
         {
             var req = Simulators.createSimulationRuns(items, GetContext(token));

--- a/CogniteSdk/src/Resources/Alpha/Simulators.cs
+++ b/CogniteSdk/src/Resources/Alpha/Simulators.cs
@@ -29,12 +29,24 @@ namespace CogniteSdk.Resources.Alpha
         }
 
         /// <summary>
+        /// Create simulation runs
+        /// </summary>
+        /// <param name="items">Simulation run items to create</param>
+        /// <param name="token">Optional cancellation token</param>
+        /// <returns>All simulation runs in project</returns>
+        public async Task<IEnumerable<SimulationRun>> CreateSimulationRunsAsync(IEnumerable<SimulationRunCreate> items, CancellationToken token = default)
+        {
+            var req = Simulators.createSimulationRuns(items, GetContext(token));
+            return await RunAsync(req).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// List all simulation runs
         /// </summary>
         /// <param name="query">Simulation run filter query</param>
         /// <param name="token">Optional cancellation token</param>
         /// <returns>All simulation runs in project</returns>
-        public async Task<IItemsWithoutCursor<SimulationRun>> ListSimulationRuns(SimulationRunQuery query, CancellationToken token = default)
+        public async Task<IItemsWithoutCursor<SimulationRun>> ListSimulationRunsAsync(SimulationRunQuery query, CancellationToken token = default)
         {
             var req = Simulators.listSimulationRuns(query, GetContext(token));
             return await RunAsync(req).ConfigureAwait(false);
@@ -46,7 +58,7 @@ namespace CogniteSdk.Resources.Alpha
         /// <param name="query">Simulation run callback query</param>
         /// <param name="token">Optional cancellation token</param>
         /// <returns>The updated simulation run</returns>
-        public async Task<IItemsWithoutCursor<SimulationRun>> SimulationRunCallback(SimulationRunCallbackItem query, CancellationToken token = default)
+        public async Task<IItemsWithoutCursor<SimulationRun>> SimulationRunCallbackAsync(SimulationRunCallbackItem query, CancellationToken token = default)
         {
             var req = Simulators.simulationRunCallback(query, GetContext(token));
             return await RunAsync(req).ConfigureAwait(false);

--- a/CogniteSdk/test/fsharp/Alpha/Simulators.fs
+++ b/CogniteSdk/test/fsharp/Alpha/Simulators.fs
@@ -34,6 +34,7 @@ let ``Create simulation runs is Ok`` () =
     task {
         // Arrange
         let now = DateTimeOffset.Now.ToUnixTimeMilliseconds()
+
         let itemToCreate =
             SimulationRunCreate(
                 SimulatorName = "DWSIM",
@@ -42,7 +43,7 @@ let ``Create simulation runs is Ok`` () =
             )
 
         // Act
-        let! res = azureDevClient.Alpha.Simulators.CreateSimulationRunsAsync([itemToCreate])
+        let! res = azureDevClient.Alpha.Simulators.CreateSimulationRunsAsync([ itemToCreate ])
 
         // Assert
         let len = Seq.length res
@@ -53,8 +54,8 @@ let ``Create simulation runs is Ok`` () =
         test <@ itemRes.ModelName = itemToCreate.ModelName @>
         test <@ itemRes.RoutineName = itemToCreate.RoutineName @>
         test <@ itemRes.Status = SimulationRunStatus.ready @>
-        test <@ now - itemRes.CreatedTime < 10000  @>
-        test <@ now - itemRes.LastUpdatedTime < 10000  @>
+        test <@ now - itemRes.CreatedTime < 10000 @>
+        test <@ now - itemRes.LastUpdatedTime < 10000 @>
 
     }
 
@@ -76,7 +77,12 @@ let ``List simulation runs is Ok`` () =
 
         test <@ res.Items |> Seq.forall (fun item -> item.SimulatorName = "DWSIM") @>
         test <@ res.Items |> Seq.forall (fun item -> item.Status = SimulationRunStatus.success) @>
-        test <@ res.Items |> Seq.forall (fun item -> item.CreatedTime > 0 && item.LastUpdatedTime > 0) @>
+
+        test
+            <@
+                res.Items
+                |> Seq.forall (fun item -> item.CreatedTime > 0 && item.LastUpdatedTime > 0)
+            @>
 
         // Assert
         test <@ len > 0 @>

--- a/CogniteSdk/test/fsharp/Alpha/Simulators.fs
+++ b/CogniteSdk/test/fsharp/Alpha/Simulators.fs
@@ -30,6 +30,36 @@ type FactIf(envVar: string, skipReason: string) =
 
 [<FactIf(envVar = "ENABLE_SIMULATORS_TESTS", skipReason = "Immature Simulator APIs")>]
 [<Trait("resource", "simulators")>]
+let ``Create simulation runs is Ok`` () =
+    task {
+        // Arrange
+        let now = DateTimeOffset.Now.ToUnixTimeMilliseconds()
+        let itemToCreate =
+            SimulationRunCreate(
+                SimulatorName = "DWSIM",
+                ModelName = "ShowerMixerIntegrationTest",
+                RoutineName = "ShowerMixerCalculation"
+            )
+
+        // Act
+        let! res = azureDevClient.Alpha.Simulators.CreateSimulationRunsAsync([itemToCreate])
+
+        // Assert
+        let len = Seq.length res
+        test <@ len = 1 @>
+        let itemRes = res |> Seq.head
+
+        test <@ itemRes.SimulatorName = itemToCreate.SimulatorName @>
+        test <@ itemRes.ModelName = itemToCreate.ModelName @>
+        test <@ itemRes.RoutineName = itemToCreate.RoutineName @>
+        test <@ itemRes.Status = SimulationRunStatus.ready @>
+        test <@ now - itemRes.CreatedTime < 10000  @>
+        test <@ now - itemRes.LastUpdatedTime < 10000  @>
+
+    }
+
+[<FactIf(envVar = "ENABLE_SIMULATORS_TESTS", skipReason = "Immature Simulator APIs")>]
+[<Trait("resource", "simulators")>]
 let ``List simulation runs is Ok`` () =
     task {
 
@@ -40,7 +70,7 @@ let ``List simulation runs is Ok`` () =
             )
 
         // Act
-        let! res = azureDevClient.Alpha.Simulators.ListSimulationRuns(query)
+        let! res = azureDevClient.Alpha.Simulators.ListSimulationRunsAsync(query)
 
         let len = Seq.length res.Items
 
@@ -68,7 +98,7 @@ let ``Callback simulation runs is Ok`` () =
                     )
             )
 
-        let! listRes = azureDevClient.Alpha.Simulators.ListSimulationRuns(listQuery)
+        let! listRes = azureDevClient.Alpha.Simulators.ListSimulationRunsAsync(listQuery)
 
         test <@ Seq.length listRes.Items > 0 @>
 
@@ -80,7 +110,7 @@ let ``Callback simulation runs is Ok`` () =
             SimulationRunCallbackItem(Id = simulationRun.Id, Status = SimulationRunStatus.success, StatusMessage = ts)
 
         // Act
-        let! res = azureDevClient.Alpha.Simulators.SimulationRunCallback query
+        let! res = azureDevClient.Alpha.Simulators.SimulationRunCallbackAsync query
         let simulationRunCallbackRes = res.Items |> Seq.head
 
         // Assert

--- a/Oryx.Cognite/src/Alpha/Simulators.fs
+++ b/Oryx.Cognite/src/Alpha/Simulators.fs
@@ -18,6 +18,16 @@ module Simulators =
 
     let runsUrl = Url +/ "runs"
     let runCallbackUrl = Url +/ "run/callback"
+    let createRunsUrl = Url +/ "run"
+
+    let createSimulationRuns
+        (items: SimulationRunCreate seq)
+        (source: HttpHandler<unit>)
+        : HttpHandler<SimulationRun seq> =
+        source
+        |> withLogMessage "simulators:createSimulationRuns"
+        |> withAlphaHeader
+        |> HttpHandler.create items createRunsUrl
 
 
     /// List all runs


### PR DESCRIPTION
- this is needed for the simulator connector to support scheduled runs
- changed method names to `...Async` to conform with other APIs