### PR TITLE
Move Annotation from Playground to the official part

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Restore tools
         run: dotnet tool restore
 
+      - name: Install dependencies
+        run: dotnet restore
+
       - name: Check formatting
         run: |
           dotnet fantomas Oryx.Cognite/src/  ./CogniteSdk.FSharp/src --check
-          dotnet format --include ./CogniteSdk.Types ./CogniteSdk/src ./CogniteSdk/test/csharp/ --verify-no-changes
-
-      - name: Install dependencies
-        run: dotnet restore
+          dotnet format --include ./CogniteSdk.Types ./CogniteSdk/src ./CogniteSdk/test/csharp/ --verify-no-changes --no-restore
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -132,11 +132,16 @@ namespace CogniteSdk
         public AlphaResource Alpha { get; }
 
         /// <summary>
-        /// Client for making requests to the API.
+        /// Client Annotations extension methods
         /// </summary>
-        /// <param name="authHandler">The authentication handler.</param>
-        /// <param name="ctx">The HTTP context to use for this session.</param>
-        private Client(Func<CancellationToken, Task<string>> authHandler, FSharpFunc<IAsyncNext<HttpContext, Unit>, Task<Unit>> ctx)
+        public AnnotationsResource Annotations { get; set; }
+
+        /// <summary>
+    /// Client for making requests to the API.
+    /// </summary>
+    /// <param name="authHandler">The authentication handler.</param>
+    /// <param name="ctx">The HTTP context to use for this session.</param>
+    private Client(Func<CancellationToken, Task<string>> authHandler, FSharpFunc<IAsyncNext<HttpContext, Unit>, Task<Unit>> ctx)
         {
             // Setup resources.
             Assets = new AssetsResource(authHandler, ctx);
@@ -157,9 +162,10 @@ namespace CogniteSdk
             Labels = new LabelsResource(authHandler, ctx);
             Groups = new GroupsResource(authHandler, ctx);
             Transformations = new TransformationsResource(authHandler, ctx);
+            Annotations = new AnnotationsResource(authHandler, ctx);
 
-            // Playground features (experimental)
-            Playground = new PlaygroundResource(authHandler, ctx);
+      // Playground features (experimental)
+      Playground = new PlaygroundResource(authHandler, ctx);
             // Beta features (experimental)
             Beta = new BetaResource(authHandler, ctx);
             // Alpha features (experimental)

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -137,11 +137,11 @@ namespace CogniteSdk
         public AlphaResource Alpha { get; }
 
         /// <summary>
-    /// Client for making requests to the API.
-    /// </summary>
-    /// <param name="authHandler">The authentication handler.</param>
-    /// <param name="ctx">The HTTP context to use for this session.</param>
-    private Client(Func<CancellationToken, Task<string>> authHandler, FSharpFunc<IAsyncNext<HttpContext, Unit>, Task<Unit>> ctx)
+        /// Client for making requests to the API.
+        /// </summary>
+        /// <param name="authHandler">The authentication handler.</param>
+        /// <param name="ctx">The HTTP context to use for this session.</param>
+        private Client(Func<CancellationToken, Task<string>> authHandler, FSharpFunc<IAsyncNext<HttpContext, Unit>, Task<Unit>> ctx)
         {
             // Setup resources.
             Assets = new AssetsResource(authHandler, ctx);

--- a/CogniteSdk/src/Client.cs
+++ b/CogniteSdk/src/Client.cs
@@ -92,6 +92,11 @@ namespace CogniteSdk
         public ThreeDAssetMappingsResource ThreeDAssetMappings { get; set; }
 
         /// <summary>
+        /// Client Annotations extension methods
+        /// </summary>
+        public AnnotationsResource Annotations { get; set; }
+
+        /// <summary>
         /// Client Token extension methods
         /// </summary>
         public TokenResource Token { get; set; }
@@ -132,11 +137,6 @@ namespace CogniteSdk
         public AlphaResource Alpha { get; }
 
         /// <summary>
-        /// Client Annotations extension methods
-        /// </summary>
-        public AnnotationsResource Annotations { get; set; }
-
-        /// <summary>
     /// Client for making requests to the API.
     /// </summary>
     /// <param name="authHandler">The authentication handler.</param>
@@ -164,8 +164,8 @@ namespace CogniteSdk
             Transformations = new TransformationsResource(authHandler, ctx);
             Annotations = new AnnotationsResource(authHandler, ctx);
 
-      // Playground features (experimental)
-      Playground = new PlaygroundResource(authHandler, ctx);
+            // Playground features (experimental)
+            Playground = new PlaygroundResource(authHandler, ctx);
             // Beta features (experimental)
             Beta = new BetaResource(authHandler, ctx);
             // Alpha features (experimental)

--- a/CogniteSdk/src/Resources/Annotations.cs
+++ b/CogniteSdk/src/Resources/Annotations.cs
@@ -11,7 +11,7 @@ using Oryx;
 using Oryx.Cognite.Playground;
 using Oryx.Pipeline;
 
-namespace CogniteSdk.Resources.Playground
+namespace CogniteSdk.Resources
 {
     /// <summary>
     /// For internal use. Contains all annotations methods.
@@ -84,7 +84,7 @@ namespace CogniteSdk.Resources.Playground
                 throw new ArgumentNullException(nameof(query));
             }
             var req = Annotations.list<Annotation>(query, GetContext(token));
-            return (ItemsWithCursor<Annotation>)await RunAsync(req).ConfigureAwait(false);
+            return await RunAsync(req).ConfigureAwait(false);
         }
         /// <summary>
         /// Asynchronously update one or more annotations. Supports partial updates, meaning that fields omitted from the
@@ -101,7 +101,7 @@ namespace CogniteSdk.Resources.Playground
             }
 
             var req = Annotations.update<Annotation>(query, GetContext(token));
-            var ret = await RunAsync<IEnumerable<Annotation>>(req).ConfigureAwait(false);
+            var ret = await RunAsync(req).ConfigureAwait(false);
             return ret;
         }
     }

--- a/CogniteSdk/src/Resources/Annotations.cs
+++ b/CogniteSdk/src/Resources/Annotations.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.FSharp.Core;
 
 using Oryx;
-using Oryx.Cognite.Playground;
+using Oryx.Cognite;
 using Oryx.Pipeline;
 
 namespace CogniteSdk.Resources

--- a/CogniteSdk/src/Resources/Playground.cs
+++ b/CogniteSdk/src/Resources/Playground.cs
@@ -32,11 +32,6 @@ namespace CogniteSdk.Resources
         public Playground.FunctionScheduleResource FunctionSchedules { get; set; }
 
         /// <summary>
-        /// Client Annotations extension methods
-        /// </summary>
-        public Playground.AnnotationsResource Annotations { get; set; }
-
-        /// <summary>
         /// Will only be instantiated by the client.
         /// </summary>
         /// <param name="authHandler">The authentication handler.</param>
@@ -46,7 +41,6 @@ namespace CogniteSdk.Resources
             Functions = new Playground.FunctionResource(authHandler, ctx);
             FunctionCalls = new Playground.FunctionCallResource(authHandler, ctx);
             FunctionSchedules = new Playground.FunctionScheduleResource(authHandler, ctx);
-            Annotations = new Playground.AnnotationsResource(authHandler, ctx);
         }
     }
 }

--- a/CogniteSdk/test/csharp/Annotations.cs
+++ b/CogniteSdk/test/csharp/Annotations.cs
@@ -28,7 +28,7 @@ namespace Test.CSharp.Integration
             // Act
             try
             {
-                await WriteClient.Playground.Annotations.DeleteAsync(query);
+                await WriteClient.Annotations.DeleteAsync(query);
             }
             catch (ResponseException)
             {
@@ -72,14 +72,14 @@ namespace Test.CSharp.Integration
                 Data = boundingVolume
             };
             var annotation = (
-                await WriteClient.Playground.Annotations.SuggestAsync(new List<AnnotationSuggest> { suggestAnnotationQuery })
+                await WriteClient.Annotations.SuggestAsync(new List<AnnotationSuggest> { suggestAnnotationQuery })
 
             ).FirstOrDefault();
 
             Assert.True(annotation.Status == "suggested", $"Expected the `suggested` Status but got {annotation.Status}");
 
             // Delete the created annotation and threedmodel
-            await WriteClient.Playground.Annotations.DeleteAsync(items: new AnnotationDelete()
+            await WriteClient.Annotations.DeleteAsync(items: new AnnotationDelete()
             { Items = new List<AnnotationId>() { new AnnotationId { Id = annotation.Id } } });
             await WriteClient.ThreeDModels.DeleteAsync(ids: new Identity[] { new Identity(threeDModel.Id) });
 

--- a/CogniteSdk/test/csharp/Annotations.cs
+++ b/CogniteSdk/test/csharp/Annotations.cs
@@ -120,7 +120,7 @@ namespace Test.CSharp.Integration
                 Status = "suggested"
             };
             var annotation = (
-                await WriteClient.Playground.Annotations.CreateAsync(new List<AnnotationCreate> { createAnnotationQuery })
+                await WriteClient.Annotations.CreateAsync(new List<AnnotationCreate> { createAnnotationQuery })
 
             ).FirstOrDefault();
 
@@ -134,7 +134,7 @@ namespace Test.CSharp.Integration
                 }
             };
 
-            var listedAnnotation = (await WriteClient.Playground.Annotations.ListAsync(listAnnotationQuery)).Items;
+            var listedAnnotation = (await WriteClient.Annotations.ListAsync(listAnnotationQuery)).Items;
             var annotationCount = listedAnnotation.Count();
 
             Assert.True(annotationCount == 1, $"Expected a single Annotation but got {annotationCount}");
@@ -162,7 +162,7 @@ namespace Test.CSharp.Integration
                     }
                 }
             };
-            var updatedAnnotation = (await WriteClient.Playground.Annotations.UpdateAsync(updateAnnotationQuery)
+            var updatedAnnotation = (await WriteClient.Annotations.UpdateAsync(updateAnnotationQuery)
                 .ConfigureAwait(false)).FirstOrDefault();
             Assert.True(updatedAnnotation.Id == annotation.Id, "The updated annotation id doesn't match with the created one.");
             Assert.True(updatedAnnotation.Status == "rejected", "The status of the annotation is not updated.");
@@ -170,7 +170,7 @@ namespace Test.CSharp.Integration
             Assert.True(updatedAnnotation.Data.Region.First().Box is not null, "The data of the annotation is not updated.");
 
             // Delete the created annotation and threedmodel
-            await WriteClient.Playground.Annotations.DeleteAsync(items: new AnnotationDelete()
+            await WriteClient.Annotations.DeleteAsync(items: new AnnotationDelete()
             { Items = new List<AnnotationId>() { new AnnotationId { Id = annotation.Id } } });
             await WriteClient.ThreeDModels.DeleteAsync(ids: new Identity[] { new Identity(threeDModel.Id) });
 

--- a/Oryx.Cognite/src/Annotations.fs
+++ b/Oryx.Cognite/src/Annotations.fs
@@ -1,13 +1,12 @@
 // Copyright 2022 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
-namespace Oryx.Cognite.Playground
+namespace Oryx.Cognite
 
 open System.Collections.Generic
 
 open Oryx
 open Oryx.Cognite
-open Oryx.Cognite.Playground
 
 open CogniteSdk
 

--- a/Oryx.Cognite/src/Handler.fs
+++ b/Oryx.Cognite/src/Handler.fs
@@ -511,4 +511,3 @@ module HttpHandler =
 
             return ret.Items
         }
-

--- a/Oryx.Cognite/src/Handler.fs
+++ b/Oryx.Cognite/src/Handler.fs
@@ -507,7 +507,7 @@ module HttpHandler =
 
             let! ret =
                 source
-                |> post<ItemsWithoutCursor<'TContent>, ItemsWithoutCursor<'TResult>> content' url
+                |> postV10<ItemsWithoutCursor<'TContent>, ItemsWithoutCursor<'TResult>> content' url
 
             return ret.Items
         }

--- a/Oryx.Cognite/src/Handler.fs
+++ b/Oryx.Cognite/src/Handler.fs
@@ -495,3 +495,20 @@ module HttpHandler =
         |> withError decodeError
         |> json jsonOptions
         |> log
+
+    let suggest<'TContent, 'TResult>
+        (content: IEnumerable<'TContent>)
+        (url: string)
+        (source: HttpHandler<unit>)
+        : HttpHandler<IEnumerable<'TResult>> =
+        http {
+            let url = url +/ "suggest"
+            let content' = ItemsWithoutCursor(Items = content)
+
+            let! ret =
+                source
+                |> post<ItemsWithoutCursor<'TContent>, ItemsWithoutCursor<'TResult>> content' url
+
+            return ret.Items
+        }
+

--- a/Oryx.Cognite/src/Oryx.Cognite.fsproj
+++ b/Oryx.Cognite/src/Oryx.Cognite.fsproj
@@ -28,10 +28,10 @@
     <Compile Include="ExtPipes.fs" />
     <Compile Include="Labels.fs" />
     <Compile Include="Groups.fs" />
+    <Compile Include="Annotations.fs" />
     <Compile Include="Transformations.fs" />
     <Compile Include="Playground/Handler.fs" />
     <Compile Include="Playground/Functions.fs" />
-    <Compile Include="Playground/Annotations.fs" />
     <Compile Include="Beta/Handler.fs" />
     <Compile Include="Beta/TemplateGroups.fs" />
     <Compile Include="Beta/DataModels.fs" />

--- a/Oryx.Cognite/src/Playground/Handler.fs
+++ b/Oryx.Cognite/src/Playground/Handler.fs
@@ -175,22 +175,6 @@ module Handler =
             return ret.Items
         }
 
-    let suggest<'TContent, 'TResult>
-        (content: IEnumerable<'TContent>)
-        (url: string)
-        (source: HttpHandler<unit>)
-        : HttpHandler<IEnumerable<'TResult>> =
-        http {
-            let url = url +/ "suggest"
-            let content' = ItemsWithoutCursor(Items = content)
-
-            let! ret =
-                source
-                |> postPlayground<ItemsWithoutCursor<'TContent>, ItemsWithoutCursor<'TResult>> content' url
-
-            return ret.Items
-        }
-
     let createWithQuery<'TContent, 'TResult>
         (content: IEnumerable<'TContent>)
         (query: IQueryParams)

--- a/cognite-sdk-dotnet.sln
+++ b/cognite-sdk-dotnet.sln
@@ -1,27 +1,23 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33712.159
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CogniteSdk.Types", "CogniteSdk.Types\CogniteSdk.Types.csproj", "{C956C2F8-DA9D-482C-9EE1-BCD8549FE726}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CogniteSdk.Types", "CogniteSdk.Types\CogniteSdk.Types.csproj", "{C956C2F8-DA9D-482C-9EE1-BCD8549FE726}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Oryx.Cognite", "Oryx.Cognite\src\Oryx.Cognite.fsproj", "{F5CEF2C3-2E62-4147-ADDB-108AB9AE27ED}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Oryx.Cognite", "Oryx.Cognite\src\Oryx.Cognite.fsproj", "{F5CEF2C3-2E62-4147-ADDB-108AB9AE27ED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CogniteSdk", "CogniteSdk\src\CogniteSdk.csproj", "{41482B89-4CC9-4DB8-91D1-ABE7E3B7C5A4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CogniteSdk", "CogniteSdk\src\CogniteSdk.csproj", "{41482B89-4CC9-4DB8-91D1-ABE7E3B7C5A4}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "CogniteSdk.Test.FSharp", "CogniteSdk\test\fsharp\CogniteSdk.Test.fsproj", "{A94F7DFA-2202-4705-AADB-FBBF739BED61}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CogniteSdk.Test.CSharp", "CogniteSdk\test\csharp\CogniteSdk.Test.csproj", "{45676171-B050-4E3F-9601-9390E7DA9AAE}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "CogniteSdk.Test", "CogniteSdk\test\fsharp\CogniteSdk.Test.fsproj", "{A94F7DFA-2202-4705-AADB-FBBF739BED61}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "playground", "playground", "{794719BD-C548-42F8-BD47-10240779604A}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpApp", "playground\fsharp\App.fsproj", "{430F4C09-1FB5-4674-987B-AAFAC8AA25DE}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpApp", "playground\csharp\App.csproj", "{334BA0EF-EDCB-4085-81F4-3EDD43069D46}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "App", "playground\fsharp\App.fsproj", "{430F4C09-1FB5-4674-987B-AAFAC8AA25DE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CogniteSdk.FSharp", "CogniteSdk.FSharp", "{B2E2DB93-62A4-4F13-AAFB-D666D5ACA0E6}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "CogniteSdk.FSharp", "CogniteSdk.FSharp\src\CogniteSdk.FSharp.fsproj", "{1F440E85-0B02-409E-9731-54D873200E46}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "CogniteSdk.FSharp", "CogniteSdk.FSharp\src\CogniteSdk.FSharp.fsproj", "{1F440E85-0B02-409E-9731-54D873200E46}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,9 +27,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C956C2F8-DA9D-482C-9EE1-BCD8549FE726}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -84,18 +77,6 @@ Global
 		{A94F7DFA-2202-4705-AADB-FBBF739BED61}.Release|x64.Build.0 = Release|Any CPU
 		{A94F7DFA-2202-4705-AADB-FBBF739BED61}.Release|x86.ActiveCfg = Release|Any CPU
 		{A94F7DFA-2202-4705-AADB-FBBF739BED61}.Release|x86.Build.0 = Release|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Debug|x64.Build.0 = Debug|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Debug|x86.Build.0 = Debug|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Release|x64.ActiveCfg = Release|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Release|x64.Build.0 = Release|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Release|x86.ActiveCfg = Release|Any CPU
-		{45676171-B050-4E3F-9601-9390E7DA9AAE}.Release|x86.Build.0 = Release|Any CPU
 		{430F4C09-1FB5-4674-987B-AAFAC8AA25DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{430F4C09-1FB5-4674-987B-AAFAC8AA25DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{430F4C09-1FB5-4674-987B-AAFAC8AA25DE}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -108,18 +89,6 @@ Global
 		{430F4C09-1FB5-4674-987B-AAFAC8AA25DE}.Release|x64.Build.0 = Release|Any CPU
 		{430F4C09-1FB5-4674-987B-AAFAC8AA25DE}.Release|x86.ActiveCfg = Release|Any CPU
 		{430F4C09-1FB5-4674-987B-AAFAC8AA25DE}.Release|x86.Build.0 = Release|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Debug|x64.Build.0 = Debug|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Debug|x86.Build.0 = Debug|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Release|Any CPU.Build.0 = Release|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Release|x64.ActiveCfg = Release|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Release|x64.Build.0 = Release|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Release|x86.ActiveCfg = Release|Any CPU
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46}.Release|x86.Build.0 = Release|Any CPU
 		{1F440E85-0B02-409E-9731-54D873200E46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1F440E85-0B02-409E-9731-54D873200E46}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1F440E85-0B02-409E-9731-54D873200E46}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -133,9 +102,11 @@ Global
 		{1F440E85-0B02-409E-9731-54D873200E46}.Release|x86.ActiveCfg = Release|Any CPU
 		{1F440E85-0B02-409E-9731-54D873200E46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{430F4C09-1FB5-4674-987B-AAFAC8AA25DE} = {794719BD-C548-42F8-BD47-10240779604A}
-		{334BA0EF-EDCB-4085-81F4-3EDD43069D46} = {794719BD-C548-42F8-BD47-10240779604A}
 		{1F440E85-0B02-409E-9731-54D873200E46} = {B2E2DB93-62A4-4F13-AAFB-D666D5ACA0E6}
 	EndGlobalSection
 EndGlobal

--- a/cognite-sdk-dotnet.sln
+++ b/cognite-sdk-dotnet.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CogniteSdk.FSharp", "Cognit
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "CogniteSdk.FSharp", "CogniteSdk.FSharp\src\CogniteSdk.FSharp.fsproj", "{1F440E85-0B02-409E-9731-54D873200E46}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CogniteSdk.Test", "CogniteSdk\test\csharp\CogniteSdk.Test.csproj", "{B42088FD-0284-46D8-8C34-EE348DC02850}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,18 @@ Global
 		{1F440E85-0B02-409E-9731-54D873200E46}.Release|x64.Build.0 = Release|Any CPU
 		{1F440E85-0B02-409E-9731-54D873200E46}.Release|x86.ActiveCfg = Release|Any CPU
 		{1F440E85-0B02-409E-9731-54D873200E46}.Release|x86.Build.0 = Release|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Debug|x64.Build.0 = Debug|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Debug|x86.Build.0 = Debug|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Release|x64.ActiveCfg = Release|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Release|x64.Build.0 = Release|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Release|x86.ActiveCfg = Release|Any CPU
+		{B42088FD-0284-46D8-8C34-EE348DC02850}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/cognite-sdk-dotnet.sln
+++ b/cognite-sdk-dotnet.sln
@@ -9,7 +9,7 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Oryx.Cognite", "Oryx.Cognit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CogniteSdk", "CogniteSdk\src\CogniteSdk.csproj", "{41482B89-4CC9-4DB8-91D1-ABE7E3B7C5A4}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "CogniteSdk.Test", "CogniteSdk\test\fsharp\CogniteSdk.Test.fsproj", "{A94F7DFA-2202-4705-AADB-FBBF739BED61}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "CogniteSdk.Test.FSharp", "CogniteSdk\test\fsharp\CogniteSdk.Test.fsproj", "{A94F7DFA-2202-4705-AADB-FBBF739BED61}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "playground", "playground", "{794719BD-C548-42F8-BD47-10240779604A}"
 EndProject
@@ -19,7 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CogniteSdk.FSharp", "Cognit
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "CogniteSdk.FSharp", "CogniteSdk.FSharp\src\CogniteSdk.FSharp.fsproj", "{1F440E85-0B02-409E-9731-54D873200E46}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CogniteSdk.Test", "CogniteSdk\test\csharp\CogniteSdk.Test.csproj", "{B42088FD-0284-46D8-8C34-EE348DC02850}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CogniteSdk.Test.CSharp", "CogniteSdk\test\csharp\CogniteSdk.Test.csproj", "{B42088FD-0284-46D8-8C34-EE348DC02850}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
I tried to move the annotation API to the official version of the STK. But both build system and F# is unknown for me. So I will need some help to do this. I have tried to move the according fs files, but I got compiler errors.

I also miss the C# test in the solution file. Why isn't not included, so we can see the build is failing before pushing the code?