### PR TITLE
Fix release and tag name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,7 +100,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ needs.build.version }}
-          release_name: Release v${{ needs.build.version }}
+          tag_name: v${{ needs.build.outputs.version }}
+          release_name: Release v${{ needs.build.outputs.version }}
           draft: false
           prerelease: false


### PR DESCRIPTION
Should be the last one. The created tag was just "v" which is problematic. I fixed it manually for 3.12.0