### PR TITLE
Fix release check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-tags: true
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          fetch-tags: true
-      - name: Get tags
-        run: git fetch --tags origin
+          fetch-depth: 0
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-tags: true
-
+      - name: Get tags
+        run: git fetch --tags origin
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:


### PR DESCRIPTION
Seems like github actions don't fetch tags by default. This is needed to prevent double release, which will only partially fail.