### PR TITLE
Add support for standardised units in timeseries

### DIFF
--- a/CogniteSdk.FSharp/src/DataPointAggregates.fs
+++ b/CogniteSdk.FSharp/src/DataPointAggregates.fs
@@ -65,10 +65,11 @@ type DataPointAggregatesQueryItem =
         x.Id |> Option.iter (fun internalId -> query.Id <- internalId)
 
         x.ExternalId |> Option.iter (fun externalId -> query.ExternalId <- externalId)
-        
+
         x.TargetUnit |> Option.iter (fun targetUnit -> query.TargetUnit <- targetUnit)
-        
-        x.TargetUnitSystem |> Option.iter (fun targetUnitSystem -> query.TargetUnitSystem <- targetUnitSystem)
+
+        x.TargetUnitSystem
+        |> Option.iter (fun targetUnitSystem -> query.TargetUnitSystem <- targetUnitSystem)
 
         x.Start |> Option.iter (fun start -> query.Start <- start)
 

--- a/CogniteSdk.FSharp/src/DataPointAggregates.fs
+++ b/CogniteSdk.FSharp/src/DataPointAggregates.fs
@@ -50,6 +50,8 @@ open DataPointAggregateType
 type DataPointAggregatesQueryItem =
     { Id: int64 option
       ExternalId: string option
+      TargetUnit: string option
+      TargetUnitSystem: string option
       Start: string option
       End: string option
       Limit: int option
@@ -63,6 +65,10 @@ type DataPointAggregatesQueryItem =
         x.Id |> Option.iter (fun internalId -> query.Id <- internalId)
 
         x.ExternalId |> Option.iter (fun externalId -> query.ExternalId <- externalId)
+        
+        x.TargetUnit |> Option.iter (fun targetUnit -> query.TargetUnit <- targetUnit)
+        
+        x.TargetUnitSystem |> Option.iter (fun targetUnitSystem -> query.TargetUnitSystem <- targetUnitSystem)
 
         x.Start |> Option.iter (fun start -> query.Start <- start)
 
@@ -86,6 +92,8 @@ type DataPointAggregatesQueryItem =
     static member Empty =
         { Id = None
           ExternalId = None
+          TargetUnit = None
+          TargetUnitSystem = None
           Start = None
           End = None
           Limit = None

--- a/CogniteSdk.FSharp/src/TimeSeries.fs
+++ b/CogniteSdk.FSharp/src/TimeSeries.fs
@@ -32,9 +32,9 @@ type TimeSeriesFilter =
         x.ExternalIdPrefix |> Option.iter (fun x -> filter.ExternalIdPrefix <- x)
 
         x.Unit |> Option.iter (fun x -> filter.Unit <- x)
-        
+
         x.UnitExternalId |> Option.iter (fun x -> filter.UnitExternalId <- x)
-        
+
         x.UnitQuantity |> Option.iter (fun x -> filter.UnitQuantity <- x)
 
         x.IsStep |> Option.iter (fun x -> filter.IsStep <- x)
@@ -81,7 +81,7 @@ type TimeSeriesFilter =
               MetaData = Map.toList x.MetaData @ Map.toList other.MetaData |> Map.ofList
               Unit = x.Unit |> Option.orElse other.Unit
               UnitExternalId = x.UnitExternalId |> Option.orElse other.UnitExternalId
-              UnitQuantity = x.UnitQuantity |> Option.orElse other.UnitQuantity 
+              UnitQuantity = x.UnitQuantity |> Option.orElse other.UnitQuantity
               CreatedTime = x.CreatedTime |> Option.orElse other.CreatedTime
               LastUpdatedTime = x.LastUpdatedTime |> Option.orElse other.LastUpdatedTime
               IsStep = x.IsStep |> Option.orElse other.IsStep

--- a/CogniteSdk.FSharp/src/TimeSeries.fs
+++ b/CogniteSdk.FSharp/src/TimeSeries.fs
@@ -9,6 +9,8 @@ open Oryx.Cognite
 type TimeSeriesFilter =
     { Name: string option
       Unit: string option
+      UnitExternalId: string option
+      UnitQuantity: string option
       IsString: bool option
       IsStep: bool option
       AssetIds: int64 list
@@ -30,6 +32,10 @@ type TimeSeriesFilter =
         x.ExternalIdPrefix |> Option.iter (fun x -> filter.ExternalIdPrefix <- x)
 
         x.Unit |> Option.iter (fun x -> filter.Unit <- x)
+        
+        x.UnitExternalId |> Option.iter (fun x -> filter.UnitExternalId <- x)
+        
+        x.UnitQuantity |> Option.iter (fun x -> filter.UnitQuantity <- x)
 
         x.IsStep |> Option.iter (fun x -> filter.IsStep <- x)
 
@@ -49,7 +55,6 @@ type TimeSeriesFilter =
 
         if not (List.isEmpty x.DataSetIds) then
             filter.DataSetIds <- x.DataSetIds |> List.map (fun x -> x.ToIdentifier()) |> Array.ofList
-
 
         x.CreatedTime |> Option.iter (fun x -> filter.CreatedTime <- x.ToTimeRange())
 
@@ -75,6 +80,8 @@ type TimeSeriesFilter =
               DataSetIds = set (x.DataSetIds @ other.DataSetIds) |> List.ofSeq
               MetaData = Map.toList x.MetaData @ Map.toList other.MetaData |> Map.ofList
               Unit = x.Unit |> Option.orElse other.Unit
+              UnitExternalId = x.UnitExternalId |> Option.orElse other.UnitExternalId
+              UnitQuantity = x.UnitQuantity |> Option.orElse other.UnitQuantity 
               CreatedTime = x.CreatedTime |> Option.orElse other.CreatedTime
               LastUpdatedTime = x.LastUpdatedTime |> Option.orElse other.LastUpdatedTime
               IsStep = x.IsStep |> Option.orElse other.IsStep
@@ -90,6 +97,8 @@ type TimeSeriesFilter =
           DataSetIds = []
           MetaData = Map.empty
           Unit = None
+          UnitExternalId = None
+          UnitQuantity = None
           IsStep = None
           IsString = None
           CreatedTime = None

--- a/CogniteSdk.Types/DataPoints/DataPointsItem.cs
+++ b/CogniteSdk.Types/DataPoints/DataPointsItem.cs
@@ -34,9 +34,16 @@ namespace CogniteSdk
         public bool? IsStep { get; set; }
 
         /// <summary>
-        /// The physical unit of the time series.
+        /// The physical unit of the time series (free-text field). Omitted if data points were converted to a
+        /// different unit.
         /// </summary>
         public string Unit { get; set; }
+        
+        /// <summary>
+        /// The physical unit of the time series (reference to unit catalog). Replaced with target unit if data
+        /// points were converted.
+        /// </summary>
+        public string UnitExternalId { get; set; }
 
         /// <summary>
         /// The cursor to get the next page of results (if available). `nextCursor` will be omitted

--- a/CogniteSdk.Types/DataPoints/DataPointsQuery.cs
+++ b/CogniteSdk.Types/DataPoints/DataPointsQuery.cs
@@ -77,6 +77,17 @@ namespace CogniteSdk
         /// </summary>
         public string Cursor { get; set; }
 
+        /// <summary>
+        /// The unit externalId of the data points returned. If the time series does not have a unitExternalId that
+        /// can be converted to the targetUnit, an error will be returned. Cannot be used with targetUnitSystem.
+        /// </summary>
+        public string TargetUnit { get; set; }
+
+        /// <summary>
+        /// The unit system of the data points returned. Cannot be used with targetUnit.
+        /// </summary>
+        public string TargetUnitSystem { get; set; }
+
         /// <inheritdoc />
         public override string ToString() => Stringable.ToString<DataPointsQueryItem>(this);
     }

--- a/CogniteSdk.Types/Timeseries/TimeSeries.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeries.cs
@@ -38,9 +38,14 @@ namespace CogniteSdk
         public bool IsString { get; set; }
 
         /// <summary>
-        /// The physical unit of the time series.
+        /// The physical unit of the time series (free-text field).
         /// </summary>
         public string Unit { get; set; }
+        
+        /// <summary>
+        /// The physical unit of the time series (reference to unit catalog). Only available for numeric time series.
+        /// </summary>
+        public string UnitExternalId { get; set; }
 
         /// <summary>
         /// AssetId for the asset this time series is linked to.

--- a/CogniteSdk.Types/Timeseries/TimeSeriesCreate.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesCreate.cs
@@ -50,9 +50,14 @@ namespace CogniteSdk
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// The physical unit of the time series.
+        /// The physical unit of the time series (free-text field).
         /// </summary>
         public string Unit { get; set; }
+        
+        /// <summary>
+        /// The physical unit of the time series (reference to unit catalog). Only available for numeric time series.
+        /// </summary>
+        public string UnitExternalId { get; set; }
 
         /// <summary>
         /// Asset this time series should be related to.

--- a/CogniteSdk.Types/Timeseries/TimeSeriesFilter.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesFilter.cs
@@ -17,12 +17,23 @@ namespace CogniteSdk
         public string Name { get; set; }
 
         /// <summary>
-        /// The unit of the time series.
+        /// The physical unit of the time series (free-text field).
         /// </summary>
         public string Unit { get; set; }
+        
+        /// <summary>
+        /// The physical unit of the time series (reference to unit catalog). Only available for numeric time series.
+        /// </summary>
+        public string UnitExternalId { get; set; }
+        
+        /// <summary>
+        /// The physical quantity of the time series (reference to unit catalog). Only available for numeric time
+        /// series.
+        /// </summary>
+        public string UnitQuantity { get; set; }
 
         /// <summary>
-        /// Filter on isStep..
+        /// Filter on isStep.
         /// </summary>
         public bool? IsStep { get; set; }
 

--- a/CogniteSdk.Types/Timeseries/TimeSeriesUpdate.cs
+++ b/CogniteSdk.Types/Timeseries/TimeSeriesUpdate.cs
@@ -32,9 +32,14 @@ namespace CogniteSdk
         public UpdateDictionary<string> Metadata { get; set; }
 
         /// <summary>
-        /// The change that will be applied to the key.
+        /// Set a new value for the Unit, or remove the value.
         /// </summary>
         public UpdateNullable<string> Unit { get; set; }
+        
+        /// <summary>
+        /// Set a new value for the UnitExternalId, or remove the value.
+        /// </summary>
+        public UpdateNullable<string> UnitExternalId { get; set; }
 
         /// <summary>
         /// Change the ID of the object.

--- a/CogniteSdk/test/fsharp/DataPoints.fs
+++ b/CogniteSdk/test/fsharp/DataPoints.fs
@@ -317,8 +317,8 @@ let ``Interact with datapoints using the new unit capabilities is Ok`` () = task
     let startTimestamp = 1704672000000L;
     let timestamps = [ startTimestamp; startTimestamp + 3600000L ; startTimestamp + 7200000L ]
     let values = [ 30.5; 29.4; 13.2 ]
-    let valuesFahrenheit = values |> List.map (fun v -> v * 1.8 + 32.0)
-    let valuesKelvin = values |> List.map (fun v -> v + 273.15)
+    let valuesFahrenheit = [ 86.9; 84.92; 55.76 ]
+    let valuesKelvin = [ 303.65; 302.55; 286.35 ]
 
     let dataPoints = NumericDatapoints()
     dataPoints.Datapoints.AddRange(

--- a/CogniteSdk/test/fsharp/DataPoints.fs
+++ b/CogniteSdk/test/fsharp/DataPoints.fs
@@ -379,7 +379,7 @@ let ``Interact with datapoints using the new unit capabilities is Ok`` () = task
                                      |> Seq.map (fun dp -> dp.Value)
 
     // Assert
-    test <@ valuesWithoutConversion = values @> // No conversion
-    test <@ valuesWithTargetUnit = valuesFahrenheit @> // Conversion from Celsius to Fahrenheit
-    test <@ valuesWithTargetUnitSystem = valuesKelvin @> // Conversion from Celsius to Kelvin
+    test <@ Seq.compareWith compare valuesWithoutConversion values = 0 @> // No conversion
+    test <@ Seq.compareWith compare valuesWithTargetUnit valuesFahrenheit = 0 @> // Conversion from Celsius to Fahrenheit
+    test <@ Seq.compareWith compare valuesWithTargetUnitSystem valuesKelvin = 0 @> // Conversion from Celsius to Kelvin
 }

--- a/CogniteSdk/test/fsharp/DataPoints.fs
+++ b/CogniteSdk/test/fsharp/DataPoints.fs
@@ -303,7 +303,7 @@ let ``Delete datapoints is Ok`` () = task {
 [<Fact>]
 let ``Interact with datapoints using the new unit capabilities is Ok`` () = task {
     // Arrange
-    let externalIdString = Guid.NewGuid().ToString();
+    let externalIdString = Guid.NewGuid().ToString()
     let unitExternalId = "temperature:deg_c"
     let dto =
         TimeSeriesCreate(

--- a/CogniteSdk/test/fsharp/TimeSeries.fs
+++ b/CogniteSdk/test/fsharp/TimeSeries.fs
@@ -502,12 +502,12 @@ let ``Interact with timeseries using the new unit capabilities is Ok`` () = task
         )
     let query1 =
         TimeSeriesSearch(
-            Filter = TimeSeriesFilter(UnitExternalId = Some unitExternalId),
+            Filter = TimeSeriesFilter(UnitExternalId = unitExternalId),
             Limit = Nullable 10
         )
     let query2 =
         TimeSeriesSearch(
-            Filter = TimeSeriesFilter(UnitQuantity = Some unitQuantity),
+            Filter = TimeSeriesFilter(UnitQuantity = unitQuantity),
             Limit = Nullable 10
         )
     let updateDto =

--- a/CogniteSdk/test/fsharp/TimeSeries.fs
+++ b/CogniteSdk/test/fsharp/TimeSeries.fs
@@ -489,7 +489,7 @@ let ``Synthetic Query with Error is Ok`` () = task {
 [<Fact>]
 let ``Interact with timeseries using the new unit capabilities is Ok`` () = task {
     // Arrange
-    let externalIdString = Guid.NewGuid().ToString();
+    let externalIdString = Guid.NewGuid().ToString()
     let unitExternalId = "temperature:deg_c"
     let unitQuantity = "Temperature"
     let dto =


### PR DESCRIPTION
This pull request includes updates to the TimeSeries and DataPoints classes. 

The changes include:
- New properties `TargetUnit` and `TargetUnitSystem` added to the `DataPointsQueryItem` class, allowing to fetch datapoints with unit conversion.
- New property `UnitExternalId` added to the `TimeSeries` classes, allowing to expose the new property on responses, creating and updating `TimeSeries` objects.
- New properties `UnitExternalId` and `UnitQuantity` added to the `TimeSeriesFilter` class, allowing to perform unit aware filtering queries to time series.