### PR TITLE
chore(tests): exit test runner if any command fails

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 source ./test_auth.sh
 dotnet test CogniteSdk/test/fsharp /p:Exclude="[xunit*]*" /p:Exclude="[CogniteSdk.Protobuf*]*" /p:CollectCoverage=true /p:CoverletOutputFormat=json /p:CoverletOutput='coverage.json'
 dotnet test CogniteSdk/test/csharp /p:Exclude="[xunit*]*" /p:Exclude="[CogniteSdk.Protobuf*]*" /p:CollectCoverage=true /p:MergeWith='../fsharp/coverage.json' /p:CoverletOutputFormat=lcov /p:CoverletOutput='../../../coverage.lcov'


### PR DESCRIPTION
currently the tests don't show failure in CI even when they fail, this is because the script always returns 0.

`set -e` fixes this issue