### PR TITLE
test(simulators): duplicated model revision externalId

### DIFF
--- a/CogniteSdk/test/fsharp/Alpha/SimulatorModelDependencies.fs
+++ b/CogniteSdk/test/fsharp/Alpha/SimulatorModelDependencies.fs
@@ -62,7 +62,7 @@ let ``Create simulator with model dependencies support and model revisions with 
         // Create model revision with external dependencies
         let modelRevisionToCreate =
             SimulatorModelRevisionCreate(
-                ExternalId = "test_model_revision_v1",
+                ExternalId = modelExternalId + "_v1",
                 ModelExternalId = modelExternalId,
                 Description = "test_model_revision_description",
                 FileId = testFileIdRevision,


### PR DESCRIPTION
In this [PR](https://github.com/cognitedata/cognite-sdk-dotnet/pull/440) we introduced support for external dependencies, for testing such feature we needed to create a model revision first, that resource is now conflicting with the previous test for model revisions because it's using the same externalId. This PR fixes that by changing the identifier.