### PR TITLE
fix(ci): Enable automatic changelog generation and update README

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,6 +115,6 @@ jobs:
         run: |
           gh release create v${{ needs.build.outputs.version }} \
             --title "Release v${{ needs.build.outputs.version }}" \
-            --notes "Automated release for version v${{ needs.build.outputs.version }}"
+            --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CogniteSdk/src/CogniteSdk.csproj
+++ b/CogniteSdk/src/CogniteSdk.csproj
@@ -8,14 +8,14 @@
     <Company>Cognite AS</Company>
     <Copyright>Cognite AS</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>package-readme.md</PackageReadmeFile>
     <AssemblyOriginatorKeyFile>../../strong_name.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="" />
-    <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="" />
+    <None Include="..\..\package-readme.md" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../CogniteSdk.Types/CogniteSdk.Types.csproj" />

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<a href="https://cognite.com/">
-    <img src="./cognite_logo.png" alt="Cognite logo" title="Cognite" align="right" height="80" />
-</a>
-
 # CogniteSdk for .NET
 
 ![Build and Test](https://github.com/cognitedata/cognite-sdk-dotnet/workflows/Build%20and%20Test/badge.svg)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<a href="https://cognite.com/">
+    <img src="./cognite_logo.png" alt="Cognite logo" title="Cognite" align="right" height="80" />
+</a>
+
 # CogniteSdk for .NET
 
 ![Build and Test](https://github.com/cognitedata/cognite-sdk-dotnet/workflows/Build%20and%20Test/badge.svg)

--- a/package-readme.md
+++ b/package-readme.md
@@ -1,0 +1,21 @@
+# CogniteSdk for .NET
+
+CogniteSdk for .NET is a cross platform asynchronous SDK for accessing the [Cognite Data Fusion API (v1)](https://docs.cognite.com/api/v1/) using .NET Standard 2.0 that works for all .NET implementations i.e both .NET Core and .NET Framework.
+
+![Build and Test](https://github.com/cognitedata/cognite-sdk-dotnet/workflows/Build%20and%20Test/badge.svg)
+[![codecov](https://codecov.io/gh/cognitedata/cognite-sdk-dotnet/branch/master/graph/badge.svg?token=da8aPB6l9U)](https://codecov.io/gh/cognitedata/cognite-sdk-dotnet)
+[![Nuget](https://img.shields.io/nuget/vpre/CogniteSdk)](https://www.nuget.org/packages/CogniteSdk/)
+
+**Unofficial**: please note that this is an unofficial and community driven SDK. Feel free to open issues, or provide PRs if you want to improve the library.
+
+The SDK may be used from both C# and F#.
+
+## Documentation
+
+- Full documentation and examples: [GitHub README](https://github.com/cognitedata/cognite-sdk-dotnet#readme)
+- [Cognite API Documentation](https://api-docs.cognite.com/)
+- [Cognite Developer Guide](https://developer.cognite.com/dev/)
+
+## Release Notes
+
+See the repository's [releases](https://github.com/cognitedata/cognite-sdk-dotnet/releases) for changelog and version history.


### PR DESCRIPTION
This PR enables automatic changelog generation for GitHub releases and removes the Cognite logo from the README which doesn't render on nuget.org.

<img width="905" height="821" alt="image" src="https://github.com/user-attachments/assets/a99f2711-44dd-43dc-b1ce-3e3d616ded36" />
