### PR TITLE
test(simint): use unique external ID for simulator model revision

### DIFF
--- a/CogniteSdk/test/fsharp/Alpha/SimulatorModels.fs
+++ b/CogniteSdk/test/fsharp/Alpha/SimulatorModels.fs
@@ -131,7 +131,7 @@ let ``Create and list simulator model revisions along with revision data is Ok``
 
         let modelRevisionToCreate =
             SimulatorModelRevisionCreate(
-                ExternalId = "test_model_revision",
+                ExternalId = $"test_model_revision_{now}",
                 ModelExternalId = modelExternalId,
                 Description = "test_model_revision_description",
                 FileId = testFileId


### PR DESCRIPTION
Fix hardcoded simulator model revision external ID in integration test. It matches with the existing pattern for `simulatorExternalId` and `modelExternalId`.