### PR TITLE
Add generic wrappers for state sets and timeseries functions

### DIFF
--- a/CogniteSdk/src/Resources/Beta.cs
+++ b/CogniteSdk/src/Resources/Beta.cs
@@ -10,10 +10,6 @@ using Oryx;
 using BetaDataModelsResource = CogniteSdk.Resources.Beta.DataModelsResource;
 // Avoid name collision with the non-beta resources
 using BetaDataPointsResource = CogniteSdk.Resources.Beta.DataPointsResource;
-<<<<<<< HEAD
-using BetaDataModelsResource = CogniteSdk.Resources.Beta.DataModelsResource;
-=======
->>>>>>> 4a79513 (Add generic wrappers for state sets and timeseries functions)
 using BetaTimeSeriesResource = CogniteSdk.Resources.Beta.TimeSeriesResource;
 
 namespace CogniteSdk.Resources

--- a/CogniteSdk/src/Resources/Beta.cs
+++ b/CogniteSdk/src/Resources/Beta.cs
@@ -7,9 +7,10 @@ using System.Threading.Tasks;
 using CogniteSdk.Resources.Beta;
 using Microsoft.FSharp.Core;
 using Oryx;
-using BetaDataModelsResource = CogniteSdk.Resources.Beta.DataModelsResource;
+
 // Avoid name collision with the non-beta resources
 using BetaDataPointsResource = CogniteSdk.Resources.Beta.DataPointsResource;
+using BetaDataModelsResource = CogniteSdk.Resources.Beta.DataModelsResource;
 using BetaTimeSeriesResource = CogniteSdk.Resources.Beta.TimeSeriesResource;
 
 namespace CogniteSdk.Resources

--- a/CogniteSdk/src/Resources/Beta.cs
+++ b/CogniteSdk/src/Resources/Beta.cs
@@ -7,10 +7,13 @@ using System.Threading.Tasks;
 using CogniteSdk.Resources.Beta;
 using Microsoft.FSharp.Core;
 using Oryx;
-
+using BetaDataModelsResource = CogniteSdk.Resources.Beta.DataModelsResource;
 // Avoid name collision with the non-beta resources
 using BetaDataPointsResource = CogniteSdk.Resources.Beta.DataPointsResource;
+<<<<<<< HEAD
 using BetaDataModelsResource = CogniteSdk.Resources.Beta.DataModelsResource;
+=======
+>>>>>>> 4a79513 (Add generic wrappers for state sets and timeseries functions)
 using BetaTimeSeriesResource = CogniteSdk.Resources.Beta.TimeSeriesResource;
 
 namespace CogniteSdk.Resources

--- a/CogniteSdk/src/Resources/Beta/StateSets.cs
+++ b/CogniteSdk/src/Resources/Beta/StateSets.cs
@@ -118,6 +118,10 @@ namespace CogniteSdk.Resources.Beta
             var req = Oryx.Cognite.Beta.DataModels.retrieveInstances<Dictionary<string, Dictionary<string, T>>>(request, GetContext(token));
             var results = await RunAsync(req).ConfigureAwait(false);
 
+            if (results?.Items == null)
+            {
+                return Enumerable.Empty<SourcedNode<T>>();
+            }
             return results.Items.Select(r => new SourcedNode<T>
             {
                 Space = r.Space,

--- a/CogniteSdk/src/Resources/Beta/StateSets.cs
+++ b/CogniteSdk/src/Resources/Beta/StateSets.cs
@@ -37,11 +37,12 @@ namespace CogniteSdk.Resources.Beta
         /// <param name="items">State sets to upsert.</param>
         /// <param name="options">Optional upsert options.</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <typeparam name="T">Type of state set properties to upsert, e.g CogniteStateSet or a custom subtype.</typeparam>
         /// <returns>The upserted state set instances.</returns>
-        public async Task<IEnumerable<SlimInstance>> UpsertAsync(
-            IEnumerable<SourcedNodeWrite<CogniteStateSet>> items,
+        public async Task<IEnumerable<SlimInstance>> UpsertAsync<T>(
+            IEnumerable<SourcedNodeWrite<T>> items,
             UpsertOptions options = null,
-            CancellationToken token = default)
+            CancellationToken token = default) where T : CogniteStateSet
         {
             if (items is null)
             {
@@ -64,7 +65,7 @@ namespace CogniteSdk.Resources.Beta
                     Type = item.Type,
                     Sources = new[]
                     {
-                        new InstanceData<CogniteStateSet>
+                        new InstanceData<T>
                         {
                             Properties = item.Properties,
                             Source = View
@@ -78,14 +79,30 @@ namespace CogniteSdk.Resources.Beta
         }
 
         /// <summary>
+        /// Create or update a list of state sets.
+        /// </summary>
+        /// <param name="items">State sets to upsert.</param>
+        /// <param name="options">Optional upsert options.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>The upserted state set instances.</returns>
+        public async Task<IEnumerable<SlimInstance>> UpsertAsync(
+            IEnumerable<SourcedNodeWrite<CogniteStateSet>> items,
+            UpsertOptions options = null,
+            CancellationToken token = default)
+        {
+            return await UpsertAsync<CogniteStateSet>(items, options, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Retrieve a list of state sets by instance ID.
         /// </summary>
         /// <param name="ids">Instance IDs to retrieve.</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <typeparam name="T">Type of state set properties to return, e.g CogniteStateSet or a custom subtype.</typeparam>
         /// <returns>The retrieved state set instances.</returns>
-        public async Task<IEnumerable<SourcedNode<CogniteStateSet>>> RetrieveAsync(
+        public async Task<IEnumerable<SourcedNode<T>>> RetrieveAsync<T>(
             IEnumerable<InstanceIdentifierWithType> ids,
-            CancellationToken token = default)
+            CancellationToken token = default) where T : CogniteStateSet
         {
             if (ids is null)
             {
@@ -98,10 +115,10 @@ namespace CogniteSdk.Resources.Beta
                 Sources = new[] { new InstanceSource { Source = View } }
             };
 
-            var req = Oryx.Cognite.Beta.DataModels.retrieveInstances<Dictionary<string, Dictionary<string, CogniteStateSet>>>(request, GetContext(token));
+            var req = Oryx.Cognite.Beta.DataModels.retrieveInstances<Dictionary<string, Dictionary<string, T>>>(request, GetContext(token));
             var results = await RunAsync(req).ConfigureAwait(false);
 
-            return results.Items.Select(r => new SourcedNode<CogniteStateSet>
+            return results.Items.Select(r => new SourcedNode<T>
             {
                 Space = r.Space,
                 ExternalId = r.ExternalId,
@@ -112,6 +129,19 @@ namespace CogniteSdk.Resources.Beta
                 DeletedTime = r.DeletedTime,
                 Properties = DMHelpers.GetFromNestedDicts(r.Properties, View)
             }).ToList();
+        }
+
+        /// <summary>
+        /// Retrieve a list of state sets by instance ID.
+        /// </summary>
+        /// <param name="ids">Instance IDs to retrieve.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>The retrieved state set instances.</returns>
+        public async Task<IEnumerable<SourcedNode<CogniteStateSet>>> RetrieveAsync(
+            IEnumerable<InstanceIdentifierWithType> ids,
+            CancellationToken token = default)
+        {
+            return await RetrieveAsync<CogniteStateSet>(ids, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/src/Resources/Beta/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/Beta/TimeSeries.cs
@@ -119,6 +119,10 @@ namespace CogniteSdk.Resources.Beta
             var req = Oryx.Cognite.Beta.DataModels.retrieveInstances<Dictionary<string, Dictionary<string, T>>>(request, GetContext(token));
             var results = await RunAsync(req).ConfigureAwait(false);
 
+            if (results?.Items == null)
+            {
+                return Enumerable.Empty<SourcedNode<T>>();
+            }
             return results.Items.Select(r => new SourcedNode<T>
             {
                 Space = r.Space,

--- a/CogniteSdk/src/Resources/Beta/TimeSeries.cs
+++ b/CogniteSdk/src/Resources/Beta/TimeSeries.cs
@@ -38,11 +38,12 @@ namespace CogniteSdk.Resources.Beta
         /// <param name="items">Time series to upsert.</param>
         /// <param name="options">Optional upsert options.</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <typeparam name="T">Type of time series properties to upsert, e.g CogniteTimeSeriesBase or a custom subtype.</typeparam>
         /// <returns>The upserted time series instances.</returns>
-        public async Task<IEnumerable<SlimInstance>> UpsertAsync(
-            IEnumerable<SourcedNodeWrite<CogniteTimeSeriesBase>> items,
+        public async Task<IEnumerable<SlimInstance>> UpsertAsync<T>(
+            IEnumerable<SourcedNodeWrite<T>> items,
             UpsertOptions options = null,
-            CancellationToken token = default)
+            CancellationToken token = default) where T : CogniteTimeSeriesBase
         {
             if (items is null)
             {
@@ -65,7 +66,7 @@ namespace CogniteSdk.Resources.Beta
                     Type = item.Type,
                     Sources = new[]
                     {
-                        new InstanceData<CogniteTimeSeriesBase>
+                        new InstanceData<T>
                         {
                             Properties = item.Properties,
                             Source = View
@@ -79,14 +80,30 @@ namespace CogniteSdk.Resources.Beta
         }
 
         /// <summary>
+        /// Create or update a list of time series.
+        /// </summary>
+        /// <param name="items">Time series to upsert.</param>
+        /// <param name="options">Optional upsert options.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>The upserted time series instances.</returns>
+        public async Task<IEnumerable<SlimInstance>> UpsertAsync(
+            IEnumerable<SourcedNodeWrite<CogniteTimeSeriesBase>> items,
+            UpsertOptions options = null,
+            CancellationToken token = default)
+        {
+            return await UpsertAsync<CogniteTimeSeriesBase>(items, options, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Retrieve a list of time series by instance ID.
         /// </summary>
         /// <param name="ids">Instance IDs to retrieve.</param>
         /// <param name="token">Optional cancellation token.</param>
+        /// <typeparam name="T">Type of time series properties to return, e.g CogniteTimeSeriesBase or a custom subtype.</typeparam>
         /// <returns>The retrieved time series instances.</returns>
-        public async Task<IEnumerable<SourcedNode<CogniteTimeSeriesBase>>> RetrieveAsync(
+        public async Task<IEnumerable<SourcedNode<T>>> RetrieveAsync<T>(
             IEnumerable<InstanceIdentifierWithType> ids,
-            CancellationToken token = default)
+            CancellationToken token = default) where T : CogniteTimeSeriesBase
         {
             if (ids is null)
             {
@@ -99,10 +116,10 @@ namespace CogniteSdk.Resources.Beta
                 Sources = new[] { new InstanceSource { Source = View } }
             };
 
-            var req = Oryx.Cognite.Beta.DataModels.retrieveInstances<Dictionary<string, Dictionary<string, CogniteTimeSeriesBase>>>(request, GetContext(token));
+            var req = Oryx.Cognite.Beta.DataModels.retrieveInstances<Dictionary<string, Dictionary<string, T>>>(request, GetContext(token));
             var results = await RunAsync(req).ConfigureAwait(false);
 
-            return results.Items.Select(r => new SourcedNode<CogniteTimeSeriesBase>
+            return results.Items.Select(r => new SourcedNode<T>
             {
                 Space = r.Space,
                 ExternalId = r.ExternalId,
@@ -113,6 +130,19 @@ namespace CogniteSdk.Resources.Beta
                 DeletedTime = r.DeletedTime,
                 Properties = DMHelpers.GetFromNestedDicts(r.Properties, View)
             }).ToList();
+        }
+
+        /// <summary>
+        /// Retrieve a list of time series by instance ID.
+        /// </summary>
+        /// <param name="ids">Instance IDs to retrieve.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>The retrieved time series instances.</returns>
+        public async Task<IEnumerable<SourcedNode<CogniteTimeSeriesBase>>> RetrieveAsync(
+            IEnumerable<InstanceIdentifierWithType> ids,
+            CancellationToken token = default)
+        {
+            return await RetrieveAsync<CogniteTimeSeriesBase>(ids, token).ConfigureAwait(false);
         }
     }
 }

--- a/CogniteSdk/test/csharp/Beta/StateTimeSeries.cs
+++ b/CogniteSdk/test/csharp/Beta/StateTimeSeries.cs
@@ -328,5 +328,92 @@ namespace Test.CSharp.Integration.Beta
             await Assert.ThrowsAnyAsync<Exception>(() =>
                 _fx.Write.Beta.TimeSeries.UpsertAsync(null));
         }
+
+        [Fact]
+        public async Task UpsertAndRetrieveStateSetAndTimeSeriesWithGenericCustomType()
+        {
+            var space = _fx.TestSpace;
+            var stateSetXid = "valve_states_generic_" + Guid.NewGuid().ToString("N");
+            var tsXid = "valve_001_state_generic_" + Guid.NewGuid().ToString("N");
+
+            var stateSetId = new InstanceIdentifierWithType(InstanceType.node, new InstanceIdentifier(space, stateSetXid));
+            var tsId = new InstanceIdentifierWithType(InstanceType.node, new InstanceIdentifier(space, tsXid));
+
+            try
+            {
+                // Exercise the generic UpsertAsync<T> overloads directly, using custom subtypes
+                // of CogniteStateSet / CogniteTimeSeriesBase instead of the base types.
+                await _fx.Write.Beta.StateSets.UpsertAsync<CustomStateSet>(new[]
+                {
+                    new SourcedNodeWrite<CustomStateSet>
+                    {
+                        Space = space,
+                        ExternalId = stateSetXid,
+                        Properties = new CustomStateSet
+                        {
+                            Name = "Valve Position States (generic)",
+                            States = new[]
+                            {
+                                new CogniteState { NumericValue = 0, StringValue = "CLOSED" },
+                                new CogniteState { NumericValue = 1, StringValue = "OPEN" }
+                            }
+                        }
+                    }
+                });
+
+                await _fx.Write.Beta.TimeSeries.UpsertAsync<CustomTimeSeries>(new[]
+                {
+                    new SourcedNodeWrite<CustomTimeSeries>
+                    {
+                        Space = space,
+                        ExternalId = tsXid,
+                        Properties = new CustomTimeSeries
+                        {
+                            Name = "Valve 001 Position (generic)",
+                            Type = CogniteSdk.DataModels.Core.TimeSeriesType.State,
+                            StateSet = new DirectRelationIdentifier(space, stateSetXid)
+                        }
+                    }
+                }, new UpsertOptions { Replace = true });
+
+                // Exercise the generic RetrieveAsync<T> overloads, deserializing into the custom subtypes.
+                var retrievedStateSet = (await _fx.Write.Beta.StateSets.RetrieveAsync<CustomStateSet>(new[] { stateSetId })).Single();
+                Assert.IsType<CustomStateSet>(retrievedStateSet.Properties);
+                Assert.Equal("Valve Position States (generic)", retrievedStateSet.Properties.Name);
+                var states = retrievedStateSet.Properties.States.ToList();
+                Assert.Equal(2, states.Count);
+                Assert.Contains(states, s => s.NumericValue == 0 && s.StringValue == "CLOSED");
+                Assert.Contains(states, s => s.NumericValue == 1 && s.StringValue == "OPEN");
+
+                var retrievedTs = (await _fx.Write.Beta.TimeSeries.RetrieveAsync<CustomTimeSeries>(new[] { tsId })).Single();
+                Assert.IsType<CustomTimeSeries>(retrievedTs.Properties);
+                Assert.Equal(CogniteSdk.DataModels.Core.TimeSeriesType.State, retrievedTs.Properties.Type);
+                Assert.NotNull(retrievedTs.Properties.StateSet);
+                Assert.Equal(space, retrievedTs.Properties.StateSet.Space);
+                Assert.Equal(stateSetXid, retrievedTs.Properties.StateSet.ExternalId);
+            }
+            finally
+            {
+                await _fx.Write.DataModels.DeleteInstances(new[] { tsId, stateSetId });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Custom subtype of <see cref="CogniteStateSet"/> used to verify that the generic
+    /// UpsertAsync/RetrieveAsync overloads on <see cref="CogniteSdk.Resources.Beta.StateSetsResource"/>
+    /// work with types other than the base <see cref="CogniteStateSet"/>.
+    /// </summary>
+    internal class CustomStateSet : CogniteStateSet
+    {
+    }
+
+    /// <summary>
+    /// Custom subtype of <see cref="CogniteTimeSeriesBase"/> used to verify that the generic
+    /// UpsertAsync/RetrieveAsync overloads on <see cref="CogniteSdk.Resources.Beta.TimeSeriesResource"/>
+    /// work with types other than the base <see cref="CogniteTimeSeriesBase"/>.
+    /// </summary>
+    internal class CustomTimeSeries : CogniteTimeSeriesBase
+    {
     }
 }


### PR DESCRIPTION
This pull request introduces generic versions of the UpsertAsync and RetrieveAsync methods in both StateSetsResource and TimeSeriesResource to support generic upstream functions that call these functions.